### PR TITLE
Allow repeatable courses across semesters

### DIFF
--- a/server/db/init.js
+++ b/server/db/init.js
@@ -35,6 +35,46 @@ try {
   console.log("  Migrated: added satisfies_json column");
 } catch (e) { /* already exists */ }
 
+// Migration: widen unique constraint from (user_id, course_code) to (user_id, course_code, semester)
+// SQLite can't ALTER constraints, so rebuild the table if the old constraint exists
+try {
+  // Check if the old constraint is still in place by trying a dummy duplicate
+  const testRow = db.prepare("SELECT id, user_id, course_code, semester FROM student_courses LIMIT 1").get();
+  if (testRow) {
+    // Try inserting a duplicate (user_id, course_code) with different semester — if it fails, old constraint is active
+    const testStmt = db.prepare("INSERT INTO student_courses (user_id, course_code, semester, status) VALUES (?, ?, ?, ?)");
+    try {
+      testStmt.run(testRow.user_id, testRow.course_code, "__MIGRATION_TEST__", "planned");
+      // If we get here, constraint already allows it (or was already migrated) — clean up test row
+      db.prepare("DELETE FROM student_courses WHERE user_id = ? AND course_code = ? AND semester = '__MIGRATION_TEST__'").run(testRow.user_id, testRow.course_code);
+    } catch (e) {
+      if (e.code === "SQLITE_CONSTRAINT_UNIQUE") {
+        // Old constraint is active — rebuild table
+        console.log("  Migrating: widening student_courses unique constraint to include semester...");
+        db.exec(`
+          CREATE TABLE student_courses_new (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            course_code TEXT NOT NULL,
+            semester TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'planned',
+            credits_override INTEGER,
+            note TEXT,
+            satisfies_json TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            pinned_program TEXT,
+            UNIQUE(user_id, course_code, semester)
+          );
+          INSERT INTO student_courses_new SELECT id, user_id, course_code, semester, status, credits_override, note, satisfies_json, created_at, pinned_program FROM student_courses;
+          DROP TABLE student_courses;
+          ALTER TABLE student_courses_new RENAME TO student_courses;
+        `);
+        console.log("  Migrated: student_courses unique constraint now includes semester");
+      }
+    }
+  }
+} catch (e) { /* table may not exist yet — schema.sql will create it correctly */ }
+
 // Migration: add active column to users
 try {
   db.prepare("ALTER TABLE users ADD COLUMN active INTEGER NOT NULL DEFAULT 1").run();

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -47,7 +47,7 @@ CREATE TABLE IF NOT EXISTS student_courses (
   note        TEXT,
   satisfies_json TEXT,           -- JSON array of {program, category} for transfer credit requirement mappings
   created_at  TEXT    NOT NULL DEFAULT (datetime('now')),
-  UNIQUE(user_id, course_code)
+  UNIQUE(user_id, course_code, semester)
 );
 
 -- Slot assignments: which requirement slot does a course fill for a student?

--- a/server/routes/students.js
+++ b/server/routes/students.js
@@ -63,13 +63,22 @@ router.post("/me/courses", (req, res) => {
 });
 
 // ── PUT /api/students/me/courses/:code ────────────────────────────────────
+// Optional ?semester= query param to target a specific instance of a repeatable course
 router.put("/me/courses/:code", (req, res) => {
   const { semester, status, creditsOverride, note, pinnedProgram, satisfiesJson } = req.body;
   const code = req.params.code.toUpperCase().replace("-", " ");
+  const targetSemester = req.query.semester; // optional: disambiguate repeatable courses
+
+  const whereClause = targetSemester
+    ? "user_id = ? AND course_code = ? AND semester = ?"
+    : "user_id = ? AND course_code = ?";
+  const whereParams = targetSemester
+    ? [req.session.userId, code, targetSemester]
+    : [req.session.userId, code];
 
   const current = db.prepare(
-    "SELECT pinned_program, satisfies_json FROM student_courses WHERE user_id = ? AND course_code = ?"
-  ).get(req.session.userId, code);
+    `SELECT pinned_program, satisfies_json FROM student_courses WHERE ${whereClause}`
+  ).get(...whereParams);
 
   db.prepare(`
     UPDATE student_courses
@@ -79,22 +88,29 @@ router.put("/me/courses/:code", (req, res) => {
         note = COALESCE(?, note),
         pinned_program = ?,
         satisfies_json = ?
-    WHERE user_id = ? AND course_code = ?
+    WHERE ${whereClause}
   `).run(
     semester ?? null, status ?? null, creditsOverride ?? null, note ?? null,
     pinnedProgram !== undefined ? pinnedProgram : (current?.pinned_program ?? null),
     satisfiesJson !== undefined ? satisfiesJson : (current?.satisfies_json ?? null),
-    req.session.userId, code
+    ...whereParams
   );
 
   res.json({ ok: true });
 });
 
 // ── DELETE /api/students/me/courses/:code ─────────────────────────────────
+// Optional ?semester= query param to target a specific instance
 router.delete("/me/courses/:code", (req, res) => {
   const code = req.params.code.toUpperCase().replace("-", " ");
-  db.prepare("DELETE FROM student_courses WHERE user_id = ? AND course_code = ?")
-    .run(req.session.userId, code);
+  const targetSemester = req.query.semester;
+  if (targetSemester) {
+    db.prepare("DELETE FROM student_courses WHERE user_id = ? AND course_code = ? AND semester = ?")
+      .run(req.session.userId, code, targetSemester);
+  } else {
+    db.prepare("DELETE FROM student_courses WHERE user_id = ? AND course_code = ?")
+      .run(req.session.userId, code);
+  }
   res.json({ ok: true });
 });
 

--- a/shared/solver.js
+++ b/shared/solver.js
@@ -74,7 +74,9 @@ function solve(studentCourses, declaredPrograms, courseMap, programMap, degreeRe
       try { satisfies = typeof sc.satisfiesJson === "string" ? JSON.parse(sc.satisfiesJson) : sc.satisfiesJson; }
       catch { /* malformed JSON — ignore */ }
     }
-    taken.set(sc.code, { ...cat, ...sc, credits: sc.creditsOverride ?? cat.credits ?? 3, pinnedProgram: sc.pinnedProgram || null, satisfies });
+    // Use composite key for repeatable courses (same code, different semester)
+    const key = taken.has(sc.code) ? `${sc.code}|${sc.semester || ""}` : sc.code;
+    taken.set(key, { ...cat, ...sc, credits: sc.creditsOverride ?? cat.credits ?? 3, pinnedProgram: sc.pinnedProgram || null, satisfies });
   }
 
   const waivedCore = new Set();


### PR DESCRIPTION
## Summary
Fixes #37 — courses like Mock Trial (PLSC 202) can now appear in multiple semesters.

- Widen `UNIQUE(user_id, course_code)` → `UNIQUE(user_id, course_code, semester)`
- Migration rebuilds table for existing DBs (SQLite can't ALTER constraints)
- Solver uses composite key when same course code appears twice
- PUT/DELETE endpoints accept `?semester=` to target specific instances

## Test plan
- [ ] PLSC 202 exists in both Spring 2025 (complete) and Spring 2026 (enrolled)
- [ ] Both instances visible on dashboard and planner
- [ ] Solver counts credits from both instances
- [ ] Transcript re-import preserves all instances of repeatable courses

🤖 Generated with [Claude Code](https://claude.com/claude-code)