### PR TITLE
P2 polish: plain language, viewport fill, college labels

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1172,7 +1172,7 @@ function CASCard({ casGrad, spanLang }) {
     <div style={{ background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 8, marginBottom: "0.75rem", overflow: "hidden" }}>
       <div onClick={() => setOpen(!open)} style={{ display: "flex", alignItems: "center", gap: "0.8rem", padding: "0.8rem 1rem", cursor: "pointer", borderLeft: `4px solid ${COLORS["CAS-GRAD"]}` }}>
         <div style={{ flex: 1 }}>
-          <div style={{ fontFamily: FONT.serif, fontSize: "1rem", fontWeight: 600, color: COLORS["CAS-GRAD"] }}>Graduation Requirements</div>
+          <div style={{ fontFamily: FONT.serif, fontSize: "1rem", fontWeight: 600, color: COLORS["CAS-GRAD"] }}>Graduation Requirements (Arts & Sciences)</div>
           <div style={{ fontFamily: FONT.mono, fontSize: "0.65rem", color: "#888" }}>{filled}/{allCats.length} satisfied</div>
         </div>
         <span style={{ fontFamily: FONT.mono, fontSize: "0.8rem", color: "#aaa", transform: open ? "rotate(180deg)" : "none", transition: "transform 0.2s" }}>▼</span>
@@ -2311,11 +2311,14 @@ function OnboardingWizard({ user, onComplete, initialStep }) {
               background: "#fff", border: `1px solid ${BORDER}`, marginBottom: 16,
               fontFamily: FONT.mono, fontSize: "0.7rem",
             }}>
-              <span style={{ color: "#22863a" }}>{parseResult.summary.exact} matched</span>
-              <span style={{ color: "#b08800" }}>{parseResult.summary.fuzzy} fuzzy</span>
-              <span style={{ color: "#c43b2d" }}>{parseResult.summary.unmatched} unmatched</span>
-              {parseResult.summary.inferred > 0 && (
-                <span style={{ color: "#b08800" }}>{parseResult.summary.inferred} inferred</span>
+              <span style={{ color: "#22863a" }}>
+                found {parseResult.summary.exact + (parseResult.summary.fuzzy || 0)} of {parseResult.summary.exact + (parseResult.summary.fuzzy || 0) + parseResult.summary.unmatched} in catalog
+              </span>
+              {parseResult.summary.fuzzy > 0 && (
+                <span style={{ color: "#b08800" }}>{parseResult.summary.fuzzy} close match{parseResult.summary.fuzzy !== 1 ? "es" : ""}</span>
+              )}
+              {parseResult.summary.unmatched > 0 && (
+                <span style={{ color: "#c43b2d" }}>{parseResult.summary.unmatched} not found</span>
               )}
             </div>
 

--- a/client/src/pages/Planner.jsx
+++ b/client/src/pages/Planner.jsx
@@ -750,6 +750,7 @@ function SemesterBucket({ term, courses, actualCourses: rawActual = [], selected
         background: dragOver ? "#e8f5e9" : "#fff",
         border: `1px ${totalCourseCount === 0 ? "dashed" : "solid"} ${dragOver ? "#22863a" : selectedCourse ? "#6f42c1" : BORDER}`,
         borderRadius: 8, padding: "0.6rem 0.7rem", marginBottom: "0.5rem",
+        flex: "1 0 auto", minHeight: totalCourseCount === 0 ? 80 : undefined,
         cursor: selectedCourse ? "pointer" : "default",
         transition: "background 0.15s, border-color 0.15s",
       }}

--- a/data/degree_requirements.json
+++ b/data/degree_requirements.json
@@ -1417,7 +1417,7 @@
     },
     {
       "code": "CORE",
-      "name": "University Core Curriculum",
+      "name": "Core Curriculum (Arts & Sciences)",
       "type": "core",
       "total_credits": 48,
       "notes": [


### PR DESCRIPTION
## Summary
- Fixes #29 — replace "matched/fuzzy/unmatched" with "found X of Y in catalog"
- Fixes #31 — semester cards flex-grow to fill viewport
- Fixes #33 — Core label → "Core Curriculum (Arts & Sciences)"

Also closed with comments:
- #34 — verified Ethical Knowledge is correctly 1 slot (LUC catalog confirms)
- #8 — term filtering already implemented in plannable-courses endpoint
- #9 — PlanPreview component already exists on dashboard

## Test plan
- [ ] Upload transcript → summary bar says "found X of Y in catalog"
- [ ] Planner with few semesters → no dead whitespace below cards
- [ ] Dashboard → "Core Curriculum (Arts & Sciences)" label

🤖 Generated with [Claude Code](https://claude.com/claude-code)