### PR TITLE
Enrollment confirmation flow and catalog refresh admin button

### DIFF
--- a/client/src/pages/AdminPanel.jsx
+++ b/client/src/pages/AdminPanel.jsx
@@ -1142,6 +1142,8 @@ const sectionStyle = {
 function ToolsTab() {
   const [scrapeStatus, setScrapeStatus] = useState(null);
   const [polling, setPolling] = useState(false);
+  const [catalogStatus, setCatalogStatus] = useState(null);
+  const [catalogPolling, setCatalogPolling] = useState(false);
 
   const loadStatus = useCallback(async () => {
     const data = await api.get("/api/admin/scrape-locus/status");
@@ -1150,6 +1152,28 @@ function ToolsTab() {
   }, []);
 
   useEffect(() => { loadStatus(); }, [loadStatus]);
+
+  // Catalog refresh
+  const loadCatalogStatus = useCallback(async () => {
+    const data = await api.get("/api/admin/scrape-catalog/status");
+    setCatalogStatus(data);
+    return data;
+  }, []);
+  useEffect(() => { loadCatalogStatus(); }, [loadCatalogStatus]);
+  useEffect(() => {
+    if (!catalogPolling) return;
+    const id = setInterval(async () => {
+      const data = await loadCatalogStatus();
+      if (data.status !== "running") setCatalogPolling(false);
+    }, 3000);
+    return () => clearInterval(id);
+  }, [catalogPolling, loadCatalogStatus]);
+  const startCatalogRefresh = async () => {
+    await api.post("/api/admin/scrape-catalog");
+    setCatalogPolling(true);
+    loadCatalogStatus();
+  };
+  const catalogRunning = catalogStatus?.status === "running";
 
   // Poll while running
   useEffect(() => {
@@ -1171,6 +1195,64 @@ function ToolsTab() {
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+      {/* Catalog Refresh */}
+      <div style={{ background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 8, padding: "1rem" }}>
+        <div style={{ fontFamily: FONT.serif, fontSize: "1rem", fontWeight: 600, marginBottom: "0.5rem" }}>
+          Course Catalog
+        </div>
+        <p style={{ fontFamily: FONT.mono, fontSize: "0.7rem", color: "#666", marginBottom: "0.75rem", lineHeight: 1.5 }}>
+          Re-scrapes the full LUC course catalog from catalog.luc.edu and reloads into the database.
+          Takes about 1 minute. Run once per academic year when the new catalog is published.
+        </p>
+
+        {catalogStatus?.stats && (
+          <div style={{ fontFamily: FONT.mono, fontSize: "0.65rem", color: "#888", marginBottom: "0.75rem" }}>
+            {catalogStatus.stats.courses} courses across {catalogStatus.stats.departments} departments
+            {catalogStatus.finishedAt && (
+              <span style={{ marginLeft: 8 }}>
+                Last run: {new Date(catalogStatus.finishedAt).toLocaleDateString()}
+              </span>
+            )}
+          </div>
+        )}
+
+        <button onClick={startCatalogRefresh} disabled={catalogRunning} style={{
+          fontFamily: FONT.mono, fontSize: "0.75rem", padding: "0.5rem 1rem",
+          background: catalogRunning ? "#ccc" : "#7a4a1a", color: "#fff",
+          border: "none", borderRadius: 4, cursor: catalogRunning ? "not-allowed" : "pointer",
+        }}>
+          {catalogRunning ? `${catalogStatus?.phase || "Running"}...` : "Refresh Course Catalog"}
+        </button>
+
+        {catalogRunning && (
+          <div style={{ fontFamily: FONT.mono, fontSize: "0.6rem", color: "#888", marginTop: "0.5rem" }}>
+            {catalogStatus?.phase === "scraping" ? "Scraping catalog.luc.edu..." : "Seeding courses into database..."} This page will update automatically.
+          </div>
+        )}
+
+        {catalogStatus?.status === "error" && (
+          <div style={{ fontFamily: FONT.mono, fontSize: "0.65rem", color: "#c43b2d", marginTop: "0.5rem" }}>
+            Error: {catalogStatus.error}
+          </div>
+        )}
+
+        {catalogStatus?.log && catalogStatus.status !== "idle" && (
+          <details style={{ marginTop: "0.75rem" }}>
+            <summary style={{ fontFamily: FONT.mono, fontSize: "0.65rem", color: "#888", cursor: "pointer" }}>
+              Refresh log
+            </summary>
+            <pre style={{
+              fontFamily: FONT.mono, fontSize: "0.55rem", background: "#1a1a1a", color: "#ccc",
+              padding: "0.5rem", borderRadius: 4, marginTop: "0.3rem", maxHeight: 300,
+              overflow: "auto", whiteSpace: "pre-wrap", wordBreak: "break-all",
+            }}>
+              {catalogStatus.log}
+            </pre>
+          </details>
+        )}
+      </div>
+
+      {/* LOCUS Offerings */}
       <div style={{ background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 8, padding: "1rem" }}>
         <div style={{ fontFamily: FONT.serif, fontSize: "1rem", fontWeight: 600, marginBottom: "0.5rem" }}>
           LOCUS Course Offerings

--- a/client/src/pages/Planner.jsx
+++ b/client/src/pages/Planner.jsx
@@ -420,6 +420,17 @@ export default function Planner({ user, onLogout }) {
           showTracker={showTracker} setShowTracker={setShowTracker}
           warnings={warnings} runValidation={runValidation}
           onSwitchToWeekly={(t) => { setView("weekly"); setWeeklyTerm(t); }}
+          onConfirmTerm={async (t) => {
+            if (!plan) return;
+            try {
+              const res = await api.post(`/api/students/me/plans/${plan.id}/confirm-term`, { term: t });
+              if (res.plan) setPlan(res.plan);
+              if (res.solver) setSolverData(res.solver);
+              loadPlannableCourses(plan.id);
+            } catch (e) {
+              setError("Failed to confirm enrollment");
+            }
+          }}
         />
       ) : (
         <WeeklyScheduleView
@@ -461,7 +472,7 @@ function SemesterPlanView({
   termFilter, setTermFilter, isSearchingCatalog, programNames, scrapedTerms,
   requirementStatus, solverData, creditStats, isMobile,
   showBrowser, setShowBrowser, showTracker, setShowTracker,
-  warnings, runValidation, onSwitchToWeekly,
+  warnings, runValidation, onSwitchToWeekly, onConfirmTerm,
 }) {
   if (isMobile) {
     return (
@@ -501,6 +512,7 @@ function SemesterPlanView({
             selectedCourse={selectedCourse} placeCourse={placeCourse}
             removeCourse={removeCourse} scrapedTerms={scrapedTerms}
             onSwitchToWeekly={onSwitchToWeekly}
+            onConfirmTerm={onConfirmTerm}
           />
         ))}
 
@@ -566,6 +578,7 @@ function SemesterPlanView({
             selectedCourse={selectedCourse} placeCourse={placeCourse}
             removeCourse={removeCourse} scrapedTerms={scrapedTerms}
             onSwitchToWeekly={onSwitchToWeekly}
+            onConfirmTerm={onConfirmTerm}
           />
         ))}
         <ValidationSection warnings={warnings} onValidate={runValidation} />
@@ -713,7 +726,7 @@ function CourseCard({ course, isPlaced, isSelected, onSelect }) {
 
 // ── Semester Bucket ──────────────────────────────────────────────────────────
 
-function SemesterBucket({ term, courses, actualCourses: rawActual = [], selectedCourse, placeCourse, removeCourse, scrapedTerms, onSwitchToWeekly }) {
+function SemesterBucket({ term, courses, actualCourses: rawActual = [], selectedCourse, placeCourse, removeCourse, scrapedTerms, onSwitchToWeekly, onConfirmTerm }) {
   const [dragOver, setDragOver] = useState(false);
   // Filter out actual courses that also exist in plan (avoid duplicate keys)
   const actualCourses = rawActual.filter(a => !courses.some(p => p.course_code === a.course_code));
@@ -846,6 +859,17 @@ function SemesterBucket({ term, courses, actualCourses: rawActual = [], selected
           }}>
             switch to weekly view to pick sections {"\u2192"}
           </div>
+        )}
+
+        {/* Confirm enrollment button — shown when this is the current term and has plan courses */}
+        {onConfirmTerm && courses.length > 0 && termOrder(term) <= termOrder(getCurrentAcademicTerm()) && (
+          <button onClick={(e) => { e.stopPropagation(); onConfirmTerm(term); }} style={{
+            fontFamily: FONT.mono, fontSize: "0.6rem", padding: "0.4rem 0.8rem", marginTop: "0.4rem",
+            background: "#6f42c1", color: "#fff", border: "none", borderRadius: 4,
+            cursor: "pointer", width: "100%",
+          }}>
+            confirm enrollment for {term}
+          </button>
         )}
       </>}
     </div>

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -21,6 +21,7 @@ const { sendInviteEmail } = require("../lib/email");
 
 // In-memory scrape job status (survives across requests, not across restarts)
 let scrapeJob = { status: "idle", log: "", startedAt: null, finishedAt: null, error: null };
+let catalogJob = { status: "idle", phase: "", log: "", startedAt: null, finishedAt: null, error: null };
 
 const router = express.Router();
 
@@ -209,6 +210,79 @@ router.get("/scrape-locus/status", (req, res) => {
     } catch (e) { /* tables may not exist */ }
   }
   res.json({ ...scrapeJob, stats });
+});
+
+// ── POST /api/admin/scrape-catalog ───────────────────────────────────────────
+router.post("/scrape-catalog", (req, res) => {
+  if (catalogJob.status === "running") {
+    return res.status(409).json({ error: "Catalog refresh already in progress", ...catalogJob });
+  }
+
+  catalogJob = { status: "running", phase: "scraping", log: "", startedAt: new Date().toISOString(), finishedAt: null, error: null };
+
+  const scrapeScript = path.join(__dirname, "../scripts/scrape-catalog.js");
+  const seedScript = path.join(__dirname, "../scripts/seed-courses.js");
+  const cwd = path.join(__dirname, "..");
+
+  // Phase 1: scrape catalog
+  const scraper = spawn(process.execPath, [scrapeScript], { cwd, env: { ...process.env } });
+  scraper.stdout.on("data", (data) => { catalogJob.log += data.toString(); });
+  scraper.stderr.on("data", (data) => { catalogJob.log += data.toString(); });
+
+  scraper.on("close", (code) => {
+    if (code !== 0) {
+      catalogJob.status = "error";
+      catalogJob.error = `Scrape failed with code ${code}`;
+      catalogJob.finishedAt = new Date().toISOString();
+      return;
+    }
+
+    // Phase 2: seed courses into DB
+    catalogJob.phase = "seeding";
+    catalogJob.log += "\n--- Seeding courses into database ---\n";
+    const seeder = spawn(process.execPath, [seedScript], { cwd, env: { ...process.env } });
+    seeder.stdout.on("data", (data) => { catalogJob.log += data.toString(); });
+    seeder.stderr.on("data", (data) => { catalogJob.log += data.toString(); });
+
+    seeder.on("close", (seedCode) => {
+      catalogJob.finishedAt = new Date().toISOString();
+      if (seedCode === 0) {
+        catalogJob.status = "done";
+        catalogJob.phase = "complete";
+      } else {
+        catalogJob.status = "error";
+        catalogJob.error = `Seed failed with code ${seedCode}`;
+      }
+    });
+
+    seeder.on("error", (err) => {
+      catalogJob.status = "error";
+      catalogJob.error = err.message;
+      catalogJob.finishedAt = new Date().toISOString();
+    });
+  });
+
+  scraper.on("error", (err) => {
+    catalogJob.status = "error";
+    catalogJob.error = err.message;
+    catalogJob.finishedAt = new Date().toISOString();
+  });
+
+  res.json({ ok: true, message: "Catalog refresh started" });
+});
+
+// ── GET /api/admin/scrape-catalog/status ─────────────────────────────────────
+router.get("/scrape-catalog/status", (req, res) => {
+  let stats = null;
+  if (catalogJob.status === "done" || catalogJob.status === "idle") {
+    try {
+      stats = {
+        courses: db.prepare("SELECT COUNT(*) as c FROM courses").get().c,
+        departments: db.prepare("SELECT COUNT(DISTINCT department) as c FROM courses").get().c,
+      };
+    } catch (e) { /* table may not exist */ }
+  }
+  res.json({ ...catalogJob, stats });
 });
 
 module.exports = router;

--- a/server/routes/plans.js
+++ b/server/routes/plans.js
@@ -385,4 +385,85 @@ function parseTime(t) {
   return h * 60 + (m || 0);
 }
 
+// ── POST /me/plans/:id/confirm-term ──────────────────────────────────────
+// Promote planned courses for a term to student_courses with status 'enrolled'
+router.post("/me/plans/:id/confirm-term", (req, res) => {
+  const { term } = req.body;
+  if (!term) return res.status(400).json({ error: "term is required" });
+
+  const plan = db.prepare("SELECT id FROM student_plans WHERE id = ? AND user_id = ?")
+    .get(req.params.id, req.session.userId);
+  if (!plan) return res.status(404).json({ error: "Plan not found" });
+
+  // Validate term is current or past
+  const currentOrder = termOrder(getCurrentAcademicTerm());
+  if (termOrder(term) > currentOrder) {
+    return res.status(400).json({ error: "Cannot confirm enrollment for a future term" });
+  }
+
+  // Fetch plan courses for this term
+  const planCourses = db.prepare(
+    "SELECT course_code, term FROM plan_courses WHERE plan_id = ? AND term = ?"
+  ).all(plan.id, term);
+
+  if (planCourses.length === 0) {
+    return res.status(400).json({ error: "No planned courses in this term" });
+  }
+
+  // Promote to student_courses and remove from plan
+  const inserted = [];
+  db.transaction(() => {
+    const insert = db.prepare(
+      "INSERT OR IGNORE INTO student_courses (user_id, course_code, semester, status) VALUES (?, ?, ?, 'enrolled')"
+    );
+    const del = db.prepare(
+      "DELETE FROM plan_courses WHERE plan_id = ? AND course_code = ? AND term = ?"
+    );
+    for (const pc of planCourses) {
+      insert.run(req.session.userId, pc.course_code, pc.term);
+      del.run(plan.id, pc.course_code, pc.term);
+      inserted.push(pc.course_code);
+    }
+  })();
+
+  // Re-run solver
+  const courseRows = db.prepare(`
+    SELECT course_code as code, semester, status,
+           credits_override as creditsOverride,
+           pinned_program as pinnedProgram,
+           satisfies_json as satisfiesJson
+    FROM student_courses WHERE user_id = ?
+  `).all(req.session.userId);
+  const programRows = db.prepare("SELECT program_id FROM student_programs WHERE user_id = ?")
+    .all(req.session.userId);
+  const declaredPrograms = programRows.map(r => r.program_id);
+  const result = solve(courseRows, declaredPrograms, courseMap, programMap, degreeRequirements);
+
+  // Return updated plan + solver
+  const updatedCourses = db.prepare(`
+    SELECT pc.course_code, pc.term, pc.section, pc.class_number,
+           c.title, c.credits, c.department
+    FROM plan_courses pc LEFT JOIN courses c ON c.code = pc.course_code
+    WHERE pc.plan_id = ? ORDER BY pc.term, pc.course_code
+  `).all(plan.id);
+  const studentCourses = db.prepare(`
+    SELECT sc.course_code, sc.semester as term, sc.status,
+           c.title, c.credits, c.department
+    FROM student_courses sc LEFT JOIN courses c ON c.code = sc.course_code
+    WHERE sc.user_id = ? AND sc.status IN ('enrolled', 'complete')
+    ORDER BY sc.semester, sc.course_code
+  `).all(req.session.userId);
+
+  res.json({ confirmed: inserted, solver: result, plan: { ...plan, courses: updatedCourses, studentCourses } });
+});
+
+function getCurrentAcademicTerm() {
+  const now = new Date();
+  const month = now.getMonth() + 1;
+  const year = now.getFullYear();
+  if (month >= 8) return `Fall ${year}`;
+  if (month >= 5) return `Summer ${year}`;
+  return `Spring ${year}`;
+}
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- Fixes #10 — Plan → enrollment flow: "confirm enrollment" button on current/past semester buckets promotes plan_courses to student_courses with status enrolled
- Fixes #15 — Catalog refresh: admin Tools tab button triggers scrape-catalog.js + seed-courses.js pipeline with live status/log

## Details

### #10 — Confirm enrollment
- New endpoint: `POST /me/plans/:id/confirm-term` with `{ term }`
- Validates plan ownership and term is current or past
- Inserts courses into student_courses (INSERT OR IGNORE), deletes from plan_courses
- Re-runs solver and returns updated plan + solver data
- Frontend: purple "confirm enrollment for {term}" button in semester buckets

### #15 — Catalog refresh
- New endpoints: `POST /api/admin/scrape-catalog` + `GET /api/admin/scrape-catalog/status`
- Two-phase: scrape (catalog.luc.edu) → seed (merge into DB)
- Admin Tools tab shows course count, last run, phase status, log output
- Mirrors existing LOCUS scrape pattern

## Test plan
- [ ] Planner: current semester bucket shows "confirm enrollment" button when plan courses exist
- [ ] Click confirm → courses move to enrolled layer, credit meters update
- [ ] Admin Tools tab → "Refresh Course Catalog" button visible
- [ ] Click refresh → shows scraping/seeding status → completes with course count

🤖 Generated with [Claude Code](https://claude.com/claude-code)