### PR TITLE
Mobile: header, credit meter, touch targets, time grid

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -768,7 +768,7 @@ function CreditMeter({ credits, hasUnmappedTransfer, onTransferWarningTap }) {
 
   return (
     <div style={{ padding: "0.8rem 0 1rem 0", borderBottom: `1px solid ${BORDER}` }}>
-      <div style={{ display: "flex", alignItems: "center", gap: "1.2rem" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: "1.2rem", flexWrap: "wrap" }}>
         <div style={{ position: "relative", flexShrink: 0 }}>
           <ProgressRing value={total} max={max} size={80} color={total >= max ? "#22863a" : "#b08800"} />
           <div style={{ position: "absolute", inset: 0, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center" }}>
@@ -992,7 +992,7 @@ function CompletedCategoriesGroup({ categories, color, conflicts, onPipClick }) 
     <div style={{ borderTop: `1px solid ${BORDER}`, paddingTop: "0.5rem" }}>
       <button type="button" aria-expanded={expanded} onClick={() => setExpanded(!expanded)} style={{
         display: "flex", alignItems: "center", gap: "0.4rem", cursor: "pointer", padding: "0.3rem 0",
-        background: "none", border: "none", textAlign: "left", width: "100%",
+        background: "none", border: "none", textAlign: "left", width: "100%", minHeight: 44,
       }}>
         <span style={{ color: TEXT.success, fontSize: TYPE.sm }}>&#10003;</span>
         <span style={{ fontFamily: FONT.mono, fontSize: TYPE.sm, fontWeight: 600, color: TEXT.success }}>

--- a/client/src/lib/ui.jsx
+++ b/client/src/lib/ui.jsx
@@ -165,8 +165,9 @@ export function StickyHeader({ user, badge, onLogout, onSettings, nav }) {
       <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
         {nav}
         {onSettings ? (
-          <button onClick={onSettings} style={{ fontFamily: FONT.mono, fontSize: TYPE.sm, padding: "0.3rem 0.6rem", background: "transparent", border: `1px solid ${BORDER}`, borderRadius: 4, cursor: "pointer", color: TEXT.secondary, minHeight: 44, display: "flex", alignItems: "center", gap: "0.3rem" }} title="Settings" aria-label="Open settings">
-            <span style={{ fontSize: TYPE.base }}>&#9881;</span> {user.name}
+          <button onClick={onSettings} style={{ fontFamily: FONT.mono, fontSize: TYPE.sm, padding: "0.3rem 0.6rem", background: "transparent", border: `1px solid ${BORDER}`, borderRadius: 4, cursor: "pointer", color: TEXT.secondary, minHeight: 44, display: "flex", alignItems: "center", gap: "0.3rem", maxWidth: 180, overflow: "hidden" }} title="Settings" aria-label="Open settings">
+            <span style={{ fontSize: TYPE.base, flexShrink: 0 }}>&#9881;</span>
+            <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{user.name}</span>
           </button>
         ) : (
           <>

--- a/client/src/pages/Planner.jsx
+++ b/client/src/pages/Planner.jsx
@@ -1547,7 +1547,7 @@ function WeeklyScheduleView({ plan, coursesByTerm, actualByTerm = {}, planTerms,
           {blocks.scheduled.length > 0 ? (
             <div style={{ ...cardStyle, padding: "0.5rem", overflow: "hidden", marginBottom: "0.5rem" }}>
               <div style={{ overflowX: "auto" }}>
-                <TimeGrid blocks={blocks.scheduled} conflictCodes={conflictCodes} gridStart={gridStart} gridEnd={gridEnd} />
+                <TimeGrid blocks={blocks.scheduled} conflictCodes={conflictCodes} gridStart={gridStart} gridEnd={gridEnd} isMobile={true} />
               </div>
             </div>
           ) : (
@@ -1678,16 +1678,17 @@ function SectionList({ sections, selectedSection, courseCode, onSectionSelect })
 
 // ── Time Grid ────────────────────────────────────────────────────────────────
 
-function TimeGrid({ blocks, conflictCodes, gridStart, gridEnd }) {
+function TimeGrid({ blocks, conflictCodes, gridStart, gridEnd, isMobile }) {
   const PX_PER_HOUR = 50;
   const ROW_HEIGHT = PX_PER_HOUR / 60; // ~0.833 px per minute
-  const LABEL_WIDTH = 50;
+  const LABEL_WIDTH = isMobile ? 36 : 50;
+  const COL_WIDTH = isMobile ? 60 : 80;
   const totalHeight = (gridEnd - gridStart) * ROW_HEIGHT;
   const rows = [];
   for (let t = gridStart; t < gridEnd; t += 60) rows.push(t);
 
   return (
-    <div style={{ position: "relative", display: "flex", width: "100%", minWidth: LABEL_WIDTH + 80 * 5 }}>
+    <div style={{ position: "relative", display: "flex", width: "100%", minWidth: LABEL_WIDTH + COL_WIDTH * 5 }}>
       {/* Time labels */}
       <div style={{ width: LABEL_WIDTH, flexShrink: 0, position: "relative", height: totalHeight }}>
         {rows.map(t => (
@@ -1702,7 +1703,7 @@ function TimeGrid({ blocks, conflictCodes, gridStart, gridEnd }) {
 
       {/* Day columns */}
       {DAY_COLS.map((day, dayIdx) => (
-        <div key={day} style={{ flex: 1, minWidth: 80, position: "relative", height: totalHeight, borderLeft: `1px solid ${BORDER}` }}>
+        <div key={day} style={{ flex: 1, minWidth: COL_WIDTH, position: "relative", height: totalHeight, borderLeft: `1px solid ${BORDER}` }}>
           {/* Day header */}
           <div style={{
             position: "sticky", top: 0, zIndex: 2,


### PR DESCRIPTION
## Summary
Fix mobile responsiveness issues for 375px phone viewports.

- **StickyHeader**: truncate long names with ellipsis (max-width 180px), gear icon stays visible
- **CreditMeter**: flex-wrap on ring + legend row so they stack on very narrow screens
- **CompletedCategoriesGroup**: add 44px min touch target on toggle button
- **TimeGrid**: responsive columns (60px mobile vs 80px desktop), total 336px fits on 375px
- **CampusDay**: verified clean at 375px — already handles mobile layout correctly

Fixes #101, Fixes #102, Fixes #103, Fixes #104

## Test plan
- [ ] Dashboard at 375px: header doesn't overflow, long name truncates
- [ ] Credit meter wraps gracefully below ~340px
- [ ] CompletedCategoriesGroup toggle easy to tap on phone
- [ ] Weekly schedule time grid fits on 375px without horizontal scroll
- [ ] Desktop time grid unchanged (80px columns)
- [ ] CampusDay mobile view: map + sidebar stack correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)