### PR TITLE
Model 56 CAS degree programs

### DIFF
--- a/data/degree_requirements.json
+++ b/data/degree_requirements.json
@@ -194,7 +194,7 @@
         "Language proficiency at 104-level required (does not count toward 33 credits).",
         "Portfolio submission required in final semester.",
         "Only 3 credits of GLST 370 count toward major.",
-        "GLST 370 (Internship) is an elective, not required \u2014 verified against LUC catalog March 2026"
+        "GLST 370 (Internship) is an elective, not required — verified against LUC catalog March 2026"
       ],
       "categories": [
         {
@@ -555,7 +555,7 @@
       ],
       "categories": [
         {
-          "name": "Introductory Courses \u2014 Tier 1",
+          "name": "Introductory Courses — Tier 1",
           "description": "Select one foundational history course",
           "slots": 1,
           "credits_per_slot": 3,
@@ -569,7 +569,7 @@
           ]
         },
         {
-          "name": "Introductory Courses \u2014 Tier 2",
+          "name": "Introductory Courses — Tier 2",
           "description": "Select one Tier 2 history course",
           "slots": 1,
           "credits_per_slot": 3,
@@ -1582,6 +1582,8225 @@
           "notes": "SPAN 102 satisfies CAS requirement; SPAN 104 satisfies GLST requirement"
         }
       ]
+    },
+    {
+      "code": "AFR-BA",
+      "name": "African Studies and the African Diaspora (BA)",
+      "type": "major",
+      "department": "AFR",
+      "total_credits": 33,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "At least 17 credit hours of AFR-BA requirements must be completed at Loyola.",
+        "Students choose one of three concentrations: History, Literature & Arts, or Social Sciences.",
+        "Concentration requires at least two courses at 200-level or higher and one at 300-level or higher.",
+        "Electives require at least one at 200-level or higher and one at 300-level or higher."
+      ],
+      "categories": [
+        {
+          "name": "Foundation Courses",
+          "description": "Complete both required foundation courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "AFR 102",
+              "required": true
+            },
+            {
+              "course": "AFR 397",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Culture & Research Courses",
+          "description": "Select one culture course and one research course from associated departments",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": "ANY_DEPT_ELECTIVE",
+          "notes": "Students can take any Culture and Research courses from departments associated with the program"
+        },
+        {
+          "name": "Concentration Courses",
+          "description": "Select four courses from one concentration: History, Literature & Arts, or Social Sciences",
+          "slots": 4,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "HIST 209",
+            "HIST 210",
+            "HIST 213",
+            "HIST 350",
+            "HIST 351",
+            "HIST 363",
+            "HIST 374",
+            "HIST 380",
+            "HIST 380A",
+            "HIST 381",
+            "ENGL 282",
+            "ENGL 282B",
+            "ENGL 282C",
+            "ENGL 316C",
+            "ENGL 384",
+            "ENGL 384B",
+            "ENGL 384C",
+            "FNAR 251",
+            "FREN 309",
+            "FREN 390",
+            "MUSC 109",
+            "MUSC 156",
+            "THTR 396",
+            "ANTH 100",
+            "ANTH 105",
+            "ANTH 211",
+            "ANTH 213",
+            "ANTH 214",
+            "ANTH 245",
+            "ANTH 332",
+            "CJC 372",
+            "PLSC 102",
+            "PLSC 218",
+            "PLSC 340",
+            "PLSC 342",
+            "PSYC 360",
+            "SOCL 101",
+            "SOCL 122",
+            "SOCL 125",
+            "SOCL 228",
+            "SOCL 250"
+          ],
+          "notes": "All four courses should be from the same concentration (History, Literature & Arts, or Social Sciences)"
+        },
+        {
+          "name": "Electives",
+          "description": "Three additional AFR courses not taken from the selected concentration",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "CIEP 333",
+            "COMM 272",
+            "FNAR 355",
+            "MUSC 104",
+            "SOWK 370"
+          ],
+          "notes": "Any AFR course or approved interdisciplinary course not already used in concentration"
+        }
+      ]
+    },
+    {
+      "code": "ARHI-BA",
+      "name": "Art History (BA)",
+      "type": "major",
+      "department": "FNAR",
+      "total_credits": 42,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "Senior thesis required (FNAR 391).",
+        "Portfolio and methods course (FNAR 390) required."
+      ],
+      "categories": [
+        {
+          "name": "Foundation Courses",
+          "description": "Complete all four required foundation courses",
+          "slots": 4,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "FNAR 199",
+              "required": true
+            },
+            {
+              "course": "FNAR 200",
+              "required": true
+            },
+            {
+              "course": "FNAR 201",
+              "required": true
+            },
+            {
+              "course": "FNAR 202",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Studio Art",
+          "description": "Select one studio art course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "FNAR 113",
+            "FNAR 114",
+            "FNAR 120",
+            "FNAR 121",
+            "FNAR 124"
+          ]
+        },
+        {
+          "name": "Early Modern Art",
+          "description": "Select one early modern art course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "FNAR 338",
+            "FNAR 343",
+            "FNAR 344",
+            "FNAR 345",
+            "FNAR 349",
+            "FNAR 360"
+          ]
+        },
+        {
+          "name": "Non-Western Art",
+          "description": "Select two non-Western art courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "FNAR 351",
+            "FNAR 352",
+            "FNAR 355",
+            "FNAR 357",
+            "FNAR 358",
+            "FNAR 359"
+          ]
+        },
+        {
+          "name": "Modern Art and Western Traditions",
+          "description": "Select one modern art course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "FNAR 207",
+            "FNAR 304",
+            "FNAR 305",
+            "FNAR 306",
+            "FNAR 365"
+          ]
+        },
+        {
+          "name": "Art History Electives",
+          "description": "Select three additional art history courses from any area",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "FNAR 207",
+            "FNAR 304",
+            "FNAR 305",
+            "FNAR 306",
+            "FNAR 338",
+            "FNAR 343",
+            "FNAR 344",
+            "FNAR 345",
+            "FNAR 349",
+            "FNAR 351",
+            "FNAR 352",
+            "FNAR 355",
+            "FNAR 357",
+            "FNAR 358",
+            "FNAR 359",
+            "FNAR 360",
+            "FNAR 365"
+          ]
+        },
+        {
+          "name": "Capstone",
+          "description": "Complete both required capstone courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "FNAR 390",
+              "required": true
+            },
+            {
+              "course": "FNAR 391",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "code": "CLST-BA",
+      "name": "Classical Civilization (BA)",
+      "type": "major",
+      "department": "CLST",
+      "total_credits": 30,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "Portfolio required as part of degree completion.",
+        "Up to 4 elective courses may be substituted with GREK or LATN courses at any level."
+      ],
+      "categories": [
+        {
+          "name": "Required Courses",
+          "description": "Complete both required courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "CLST 275",
+              "required": true
+            },
+            {
+              "course": "CLST 276",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Literature Requirement",
+          "description": "Select one classical literature course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "CLST 271",
+            "CLST 271G",
+            "CLST 272",
+            "CLST 273",
+            "CLST 273G",
+            "CLST 279",
+            "CLST 280",
+            "CLST 283"
+          ]
+        },
+        {
+          "name": "Electives",
+          "description": "Select five CLST courses (up to 4 may be GREK or LATN at any level)",
+          "slots": 5,
+          "credits_per_slot": 3,
+          "eligible_courses": "ANY_DEPT_ELECTIVE",
+          "notes": "Any CLST course, or GREK/LATN courses at any level (max 4 substitutions)"
+        },
+        {
+          "name": "Capstone",
+          "description": "Complete both capstone courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "CLST 383",
+              "required": true
+            },
+            {
+              "course": "CLST 384",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "code": "DANC-BA",
+      "name": "Dance (BA)",
+      "type": "major",
+      "department": "DANC",
+      "total_credits": 40,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "Many courses are 1 or 2 credits rather than the standard 3.",
+        "Some applied courses must be repeated multiple semesters.",
+        "Senior Showcase Capstone (DANC 380) required."
+      ],
+      "categories": [
+        {
+          "name": "Foundation Courses",
+          "description": "Complete required foundation courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "DANC 250",
+              "required": true
+            },
+            {
+              "course": "DANC 270",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Foundation Practicum",
+          "description": "Select one practicum",
+          "slots": 1,
+          "credits_per_slot": 2,
+          "eligible_courses": [
+            "THTR 321C",
+            "THTR 321E"
+          ]
+        },
+        {
+          "name": "Applied Courses — Ballet",
+          "description": "Complete ballet sequence (8 semesters total, 1 credit each)",
+          "slots": 8,
+          "credits_per_slot": 1,
+          "eligible_courses_fixed": [
+            {
+              "course": "DANC 341",
+              "required": true
+            },
+            {
+              "course": "DANC 343",
+              "required": true
+            }
+          ],
+          "notes": "DANC 341 taken 4 times, DANC 343 taken 4 times"
+        },
+        {
+          "name": "Applied Courses — Pointe",
+          "description": "Select pointe coursework (2 credits)",
+          "slots": 2,
+          "credits_per_slot": 1,
+          "eligible_courses": [
+            "DANC 312",
+            "DANC 314"
+          ]
+        },
+        {
+          "name": "Applied Courses — Jazz",
+          "description": "Select one jazz course",
+          "slots": 1,
+          "credits_per_slot": 2,
+          "eligible_courses": [
+            "DANC 232",
+            "DANC 331"
+          ]
+        },
+        {
+          "name": "Applied Courses — Modern",
+          "description": "Complete modern dance sequence (4 semesters, 1 credit each)",
+          "slots": 4,
+          "credits_per_slot": 1,
+          "eligible_courses_fixed": [
+            {
+              "course": "DANC 224",
+              "required": true
+            },
+            {
+              "course": "DANC 324",
+              "required": true
+            }
+          ],
+          "notes": "DANC 224 taken 2 times, DANC 324 taken 2 times"
+        },
+        {
+          "name": "Applied Courses — Global Dance",
+          "description": "Complete global dance course",
+          "slots": 1,
+          "credits_per_slot": 2,
+          "eligible_courses_fixed": [
+            {
+              "course": "DANC 275",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Electives",
+          "description": "Select dance electives (4 credits total)",
+          "slots": 2,
+          "credits_per_slot": 2,
+          "eligible_courses": [
+            "DANC 260",
+            "DANC 261",
+            "DANC 280",
+            "DANC 395",
+            "DANC 397",
+            "DANC 398"
+          ],
+          "notes": "Any DANC course beyond degree requirements also eligible"
+        },
+        {
+          "name": "Synthesis — Rehearsal & Performance",
+          "description": "Complete rehearsal and performance (2 semesters, 1 credit each)",
+          "slots": 2,
+          "credits_per_slot": 1,
+          "eligible_courses_fixed": [
+            {
+              "course": "DANC 323",
+              "required": true
+            }
+          ],
+          "notes": "Taken twice"
+        },
+        {
+          "name": "Synthesis — Pedagogy & Composition",
+          "description": "Complete pedagogy and composition courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "DANC 360",
+              "required": true
+            },
+            {
+              "course": "DANC 370",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Synthesis — Capstone",
+          "description": "Complete internship and senior showcase",
+          "slots": 2,
+          "credits_per_slot": 1,
+          "eligible_courses_fixed": [
+            {
+              "course": "DANC 394",
+              "required": true
+            },
+            {
+              "course": "DANC 380",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "code": "ENGL-BA-CW",
+      "name": "English — Creative Writing Concentration (BA)",
+      "type": "major",
+      "department": "ENGL",
+      "total_credits": 36,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "This is a concentration within the English BA, not a separate major.",
+        "Pre-1900 literature requirement: at least one course prior to 1700 AND at least one after 1700.",
+        "Students may repeat any advanced workshop (ENGL 392/397/398) twice.",
+        "UCLR 100E Interpreting Literature may count as the ENGL elective."
+      ],
+      "categories": [
+        {
+          "name": "Creative Writing Requirement",
+          "description": "Complete the required writing of poetry course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "ENGL 317",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Shakespeare Requirement",
+          "description": "Select one Shakespeare course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENGL 326",
+            "ENGL 327"
+          ]
+        },
+        {
+          "name": "Literary Theory/Criticism",
+          "description": "Select one literary theory or criticism course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENGL 354",
+            "ENGL 355"
+          ]
+        },
+        {
+          "name": "Fiction Writing",
+          "description": "Select one fiction writing course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENGL 318",
+            "ENGL 318R"
+          ]
+        },
+        {
+          "name": "Creative Nonfiction",
+          "description": "Select one creative nonfiction course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENGL 319",
+            "ENGL 357"
+          ]
+        },
+        {
+          "name": "English Literature Before 1900",
+          "description": "Select three pre-1900 literature courses (at least one pre-1700 and one post-1700)",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENGL 282B",
+            "ENGL 306A",
+            "ENGL 306B",
+            "ENGL 312A",
+            "ENGL 312B",
+            "ENGL 313A",
+            "ENGL 313B",
+            "ENGL 320",
+            "ENGL 321",
+            "ENGL 322",
+            "ENGL 323",
+            "ENGL 325",
+            "ENGL 327",
+            "ENGL 328",
+            "ENGL 329",
+            "ENGL 338",
+            "ENGL 340",
+            "ENGL 343",
+            "ENGL 359A",
+            "ENGL 359B",
+            "ENGL 362A",
+            "ENGL 362B",
+            "ENGL 363B",
+            "ENGL 368A",
+            "ENGL 368B",
+            "ENGL 369A",
+            "ENGL 369B",
+            "ENGL 372A",
+            "ENGL 372B",
+            "ENGL 375",
+            "ENGL 376",
+            "ENGL 379A",
+            "ENGL 379B",
+            "ENGL 381A",
+            "ENGL 381B",
+            "ENGL 382A",
+            "ENGL 382B",
+            "ENGL 384B"
+          ],
+          "notes": "At least one course prior to 1700 and at least one course after 1700 required"
+        },
+        {
+          "name": "English Literature Since 1900",
+          "description": "Select one post-1900 literature course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENGL 282C",
+            "ENGL 306C",
+            "ENGL 312C",
+            "ENGL 313C",
+            "ENGL 315C",
+            "ENGL 316C",
+            "ENGL 344",
+            "ENGL 345",
+            "ENGL 348",
+            "ENGL 351",
+            "ENGL 359C",
+            "ENGL 361",
+            "ENGL 362C",
+            "ENGL 363C",
+            "ENGL 367",
+            "ENGL 368C",
+            "ENGL 371",
+            "ENGL 372C",
+            "ENGL 377",
+            "ENGL 379",
+            "ENGL 379C",
+            "ENGL 381C",
+            "ENGL 382C",
+            "ENGL 384C"
+          ]
+        },
+        {
+          "name": "ENGL Elective",
+          "description": "Select one additional English elective",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": "ANY_DEPT_ELECTIVE",
+          "notes": "Any ENGL course; UCLR 100E may also count"
+        },
+        {
+          "name": "Advanced Writing Workshop Capstone",
+          "description": "Select two advanced writing workshops",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENGL 392",
+            "ENGL 397",
+            "ENGL 398"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "FREN-BA",
+      "name": "French (BA)",
+      "type": "major",
+      "department": "FREN",
+      "total_credits": 30,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "Prerequisites FREN 101-104 do not count toward the 30 major credits.",
+        "Senior Capstone E-Portfolio required for graduation.",
+        "Students are encouraged to study abroad."
+      ],
+      "categories": [
+        {
+          "name": "Composition & Conversation",
+          "description": "Complete both composition and conversation courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "FREN 250",
+              "required": true
+            },
+            {
+              "course": "FREN 251",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "French Literature & Culture Survey",
+          "description": "Complete both literature and culture survey courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "FREN 270",
+              "required": true
+            },
+            {
+              "course": "FREN 271",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Stylistics or Professional French",
+          "description": "Select one course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "FREN 301",
+            "FREN 302"
+          ]
+        },
+        {
+          "name": "Le Grand Siecle",
+          "description": "Complete the required Le Grand Siecle course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "FREN 317",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "300-Level Electives",
+          "description": "Select four additional FREN 300-level courses",
+          "slots": 4,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "FREN 300",
+            "FREN 301",
+            "FREN 302",
+            "FREN 317"
+          ],
+          "notes": "Any FREN 300-level course; catalog lists limited codes but department offers additional 300-level options"
+        }
+      ]
+    },
+    {
+      "code": "GREK-BA",
+      "name": "Ancient Greek (BA)",
+      "type": "major",
+      "department": "GREK",
+      "total_credits": 36,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "Students may begin without prior Greek language experience.",
+        "Prerequisites GREK 101-102 do not count toward the 36 major credits.",
+        "At least two GREK electives must be at the 300-level.",
+        "Portfolio required as part of degree completion."
+      ],
+      "categories": [
+        {
+          "name": "Greek Language Electives",
+          "description": "Six or more GREK courses beyond the 100-level sequence; at least two at the 300-level",
+          "slots": 6,
+          "credits_per_slot": 3,
+          "eligible_courses": "ANY_DEPT_ELECTIVE",
+          "notes": "Any GREK course beyond 102; minimum 2 courses at 300-level"
+        },
+        {
+          "name": "Electives in Greek, Latin, or Classical Civilization",
+          "description": "Select four courses from GREK, LATN, or CLST",
+          "slots": 4,
+          "credits_per_slot": 3,
+          "eligible_courses": "ANY_DEPT_ELECTIVE",
+          "notes": "Any GREK, LATN, or CLST course"
+        },
+        {
+          "name": "Capstone",
+          "description": "Complete both capstone courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "CLST 383",
+              "required": true
+            },
+            {
+              "course": "CLST 384",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "code": "ITAL-BA",
+      "name": "Italian (BA)",
+      "type": "major",
+      "department": "ITAL",
+      "total_credits": 30,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "Prerequisites ITAL 101-104 do not count toward the 30 major credits.",
+        "Of the six 300-level courses taken, four must be literature courses.",
+        "Senior Capstone E-Portfolio required for graduation.",
+        "Students with prior Italian knowledge must consult faculty before registering."
+      ],
+      "categories": [
+        {
+          "name": "Required 200-Level Courses",
+          "description": "Complete all four 200-level courses",
+          "slots": 4,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "ITAL 250",
+              "required": true
+            },
+            {
+              "course": "ITAL 251",
+              "required": true
+            },
+            {
+              "course": "ITAL 270",
+              "required": true
+            },
+            {
+              "course": "ITAL 271",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Required 300-Level Course",
+          "description": "Complete the required Dante course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "ITAL 312",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "300-Level Electives",
+          "description": "Select five additional 300-level courses (four must be literature courses)",
+          "slots": 5,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ITAL 300",
+            "ITAL 301",
+            "ITAL 308",
+            "ITAL 314",
+            "ITAL 315",
+            "ITAL 316",
+            "ITAL 317",
+            "ITAL 318",
+            "ITAL 319",
+            "ITAL 320",
+            "ITAL 331",
+            "ITAL 340",
+            "ITAL 390",
+            "ITAL 399"
+          ],
+          "notes": "Four of the six total 300-level courses (including ITAL 312) must be literature courses"
+        }
+      ]
+    },
+    {
+      "code": "ITST-BA",
+      "name": "Italian Studies (BA)",
+      "type": "major",
+      "department": "ITAL",
+      "total_credits": 30,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "5 of the 10 total courses must be in Italian language.",
+        "Students placed based on language competency — beginners take ITAL 101-104 sequence.",
+        "Senior portfolio required for reflection and program assessment.",
+        "Internship may be completed in Chicago or Rome."
+      ],
+      "categories": [
+        {
+          "name": "Introductory Interdisciplinary Course",
+          "description": "Complete the required introduction to Italian culture",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "LITR 161",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Italian Language Courses",
+          "description": "Complete five Italian language courses (placement determines starting level)",
+          "slots": 5,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ITAL 101",
+            "ITAL 102",
+            "ITAL 103",
+            "ITAL 104",
+            "ITAL 250",
+            "ITAL 251",
+            "ITAL 270",
+            "ITAL 271"
+          ],
+          "notes": "Students placing above 104 choose from higher-level ITAL courses to ensure 5 of 10 total courses are in Italian"
+        },
+        {
+          "name": "Italian Studies Electives",
+          "description": "Select three interdisciplinary elective courses",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "CJC 351",
+            "CLST 206",
+            "CLST 207",
+            "CLST 276",
+            "CLST 277",
+            "CLST 295",
+            "CLST 334R",
+            "ENGL 318R",
+            "ENVS 227R",
+            "FNAR 200",
+            "FNAR 201",
+            "FNAR 342",
+            "FNAR 343",
+            "FNAR 344",
+            "FNAR 345",
+            "HIST 253A",
+            "HIST 308B",
+            "HIST 314",
+            "HIST 324",
+            "HIST 379A",
+            "HIST 379B",
+            "ITAL 251",
+            "ITAL 270",
+            "ITAL 271",
+            "ITAL 300",
+            "ITAL 305",
+            "ITAL 312",
+            "ITAL 315",
+            "ITAL 318",
+            "ITAL 319",
+            "ITAL 331",
+            "ITAL 340",
+            "ITAL 390",
+            "ITAL 399",
+            "LITR 264",
+            "LITR 267",
+            "LITR 268",
+            "LITR 268R",
+            "LITR 291",
+            "MUSC 154R",
+            "PHIL 277R",
+            "PHIL 288R",
+            "PHIL 304",
+            "PLSC 365",
+            "ROST 382",
+            "SOCL 267",
+            "THEO 266",
+            "THEO 279"
+          ]
+        },
+        {
+          "name": "Internship or Service Learning",
+          "description": "Complete the required internship",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "ITAL 395",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "code": "LATN-BA",
+      "name": "Latin (BA)",
+      "type": "major",
+      "department": "LATN",
+      "total_credits": 36,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "Students may begin without prior Latin language experience.",
+        "Prerequisites LATN 101-102 required before elective Latin courses.",
+        "At least two Latin electives must be at the 300-level.",
+        "Portfolio required as part of degree completion."
+      ],
+      "categories": [
+        {
+          "name": "Latin Language Electives",
+          "description": "Six or more LATN courses beyond the 100-level sequence; at least two at the 300-level",
+          "slots": 6,
+          "credits_per_slot": 3,
+          "eligible_courses": "ANY_DEPT_ELECTIVE",
+          "notes": "Any LATN course beyond 102; minimum 2 courses at 300-level"
+        },
+        {
+          "name": "Electives in Greek, Latin, or Classical Civilization",
+          "description": "Select four courses from GREK, LATN, or CLST",
+          "slots": 4,
+          "credits_per_slot": 3,
+          "eligible_courses": "ANY_DEPT_ELECTIVE",
+          "notes": "Any GREK, LATN, or CLST course"
+        },
+        {
+          "name": "Capstone",
+          "description": "Complete both capstone courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "CLST 383",
+              "required": true
+            },
+            {
+              "course": "CLST 384",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "code": "RELS-BA",
+      "name": "Religious Studies (BA)",
+      "type": "major",
+      "department": "THEO",
+      "total_credits": 36,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "Minimum 5 of 12 courses must be at the 300-level or higher.",
+        "At least 18 credits must be completed at Loyola.",
+        "Up to 3 elective courses may be taken outside Theology with director permission.",
+        "THEO 100 may be substituted with HONR 101, HONR D101, THEO 190, or PHIL 190.",
+        "Honors Track requires 3.5+ GPA."
+      ],
+      "categories": [
+        {
+          "name": "Christian Traditions",
+          "description": "Select one course in Christian traditions",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "THEO 100",
+            "THEO 185",
+            "THEO 232",
+            "THEO 265",
+            "THEO 267",
+            "THEO 279",
+            "THEO 281",
+            "THEO 317",
+            "THEO 318",
+            "HONR 101",
+            "HONR D101",
+            "THEO 190",
+            "PHIL 190"
+          ]
+        },
+        {
+          "name": "Non-Christian Traditions",
+          "description": "Select three courses in non-Christian traditions",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "THEO 272",
+            "THEO 282",
+            "THEO 295",
+            "THEO 297",
+            "THEO 299"
+          ]
+        },
+        {
+          "name": "Religious Comparisons or Themes",
+          "description": "Select two courses in comparative religion or themes",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "THEO 107",
+            "THEO 186",
+            "THEO 278",
+            "THEO 393"
+          ]
+        },
+        {
+          "name": "Religious Studies Electives",
+          "description": "Select five elective courses at the 200-level or higher",
+          "slots": 5,
+          "credits_per_slot": 3,
+          "eligible_courses": "ANY_DEPT_ELECTIVE",
+          "notes": "THEO 200-level or higher; up to 3 may be outside Theology with director permission"
+        },
+        {
+          "name": "Capstone",
+          "description": "Select one capstone course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "THEO 353",
+            "THEO 373",
+            "THEO 280"
+          ],
+          "notes": "THEO 373 requires approval; THEO 280 for interdisciplinary track must be Engaged Learning"
+        }
+      ]
+    },
+    {
+      "code": "THTR-BA",
+      "name": "Theatre (BA)",
+      "type": "major",
+      "department": "THTR",
+      "total_credits": 47,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "Transfer students must complete minimum 24 credit hours at Loyola.",
+        "3 of the 12 elective credits must be Engaged Learning designated.",
+        "Practicum courses are 1-2 credits each, totaling 5 credits."
+      ],
+      "categories": [
+        {
+          "name": "Introduction",
+          "description": "Select one introductory course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "THTR 100",
+            "THTR 203"
+          ]
+        },
+        {
+          "name": "Foundation Courses",
+          "description": "Complete all required foundation courses",
+          "slots": 7,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "THTR 252",
+              "required": true
+            },
+            {
+              "course": "THTR 261",
+              "required": true
+            },
+            {
+              "course": "THTR 364",
+              "required": true
+            },
+            {
+              "course": "THTR 365",
+              "required": true
+            },
+            {
+              "course": "THTR 366",
+              "required": true
+            },
+            {
+              "course": "THTR 367",
+              "required": true
+            },
+            {
+              "course": "THTR 375",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Emphasis Course",
+          "description": "Select one emphasis course (acting or design)",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "THTR 267",
+            "THTR 352"
+          ]
+        },
+        {
+          "name": "Practicum",
+          "description": "Select practicum courses totaling 8 credits",
+          "slots": 8,
+          "credits_per_slot": 1,
+          "eligible_courses": [
+            "THTR 321C",
+            "THTR 321S",
+            "THTR 321E",
+            "THTR 321R",
+            "THTR 321P"
+          ],
+          "notes": "THTR 321C, 321S, and 321E are 2 credits each; THTR 321R and 321P are 1 credit each. Select courses totaling 8 credits."
+        },
+        {
+          "name": "Electives",
+          "description": "Select theatre electives totaling 12 credits (3 must be Engaged Learning)",
+          "slots": 4,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "THTR 204",
+            "THTR 227",
+            "THTR 241",
+            "THTR 267",
+            "THTR 275",
+            "THTR 300",
+            "THTR 305",
+            "THTR 323",
+            "THTR 324D",
+            "THTR 324M",
+            "THTR 327",
+            "THTR 329",
+            "THTR 331",
+            "THTR 335",
+            "THTR 336",
+            "THTR 341",
+            "THTR 344",
+            "THTR 345",
+            "THTR 346",
+            "THTR 348",
+            "THTR 352",
+            "THTR 353",
+            "THTR 354",
+            "THTR 368",
+            "THTR 369",
+            "THTR 377",
+            "THTR 394",
+            "THTR 395",
+            "THTR 397",
+            "THTR 399"
+          ],
+          "notes": "3 of the 12 credits must be Engaged Learning designated"
+        }
+      ]
+    },
+    {
+      "code": "WSGS-BA",
+      "name": "Women's Studies and Gender Studies (BA)",
+      "type": "major",
+      "department": "WSGS",
+      "total_credits": 36,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "Minimum 21 hours (7 courses) must be at the 300-level or above.",
+        "At least 2 of the 5 electives must be at the 300-level."
+      ],
+      "categories": [
+        {
+          "name": "Required Courses",
+          "description": "Complete all six required WSGS courses",
+          "slots": 6,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "WSGS 101",
+              "required": true
+            },
+            {
+              "course": "WSGS 201",
+              "required": true
+            },
+            {
+              "course": "WSGS 330",
+              "required": true
+            },
+            {
+              "course": "WSGS 391",
+              "required": true
+            },
+            {
+              "course": "WSGS 398",
+              "required": true
+            },
+            {
+              "course": "WSGS 399",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Theory Requirement",
+          "description": "Select one theory course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "PLSC 312",
+            "ENGL 307",
+            "WSGS 380"
+          ]
+        },
+        {
+          "name": "Electives",
+          "description": "Select five elective courses from WSGS and cross-listed offerings (at least 2 at 300-level)",
+          "slots": 5,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "WSGS 380",
+            "ANTH 106",
+            "ANTH 203",
+            "ANTH 205",
+            "ANTH 245",
+            "ANTH 307",
+            "ANTH 346",
+            "BIOL 346",
+            "CJC 370",
+            "CJC 373",
+            "CLST 271G",
+            "CLST 273G",
+            "CLST 295",
+            "COMM 281",
+            "ENGL 283",
+            "ENGL 306",
+            "ENGL 306A",
+            "ENGL 306B",
+            "ENGL 306C",
+            "ENGL 307",
+            "ENGL 369A",
+            "ENGL 369B",
+            "FNAR 207",
+            "FNAR 360",
+            "HIST 290A",
+            "HIST 310C",
+            "HIST 310L",
+            "HIST 329",
+            "HIST 329C",
+            "HIST 331A",
+            "HIST 337A",
+            "HIST 339F",
+            "HIST 341C",
+            "HIST 349A",
+            "HIST 358",
+            "HIST 377",
+            "HIST 381",
+            "HIST 382",
+            "HIST 389B",
+            "HIST 389C",
+            "LITR 291",
+            "PHIL 322",
+            "PLSC 251",
+            "PLSC 312",
+            "PLSC 319",
+            "PLSC 355C",
+            "PLSC 399",
+            "PSYC 235",
+            "PSYC 238",
+            "PSYC 239",
+            "PSYC 340",
+            "PSYC 360",
+            "SOCL 123",
+            "SOCL 171",
+            "SOCL 210",
+            "SOCL 239",
+            "SOCL 240",
+            "SOCL 250",
+            "SOCL 262",
+            "SOCL 266",
+            "SPAN 361",
+            "THEO 278",
+            "THEO 365"
+          ],
+          "notes": "At least 2 of the 5 electives must be at the 300-level"
+        }
+      ]
+    },
+    {
+      "code": "ENVS-BA",
+      "name": "Environmental Studies (BA)",
+      "type": "major",
+      "department": "ENVS",
+      "total_credits": 51,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "core_waivers": [],
+      "notes": [
+        "School of Environmental Sustainability (SES), not College of Arts & Sciences.",
+        "Foreign language required: 102-level or above, or SES proficiency exam.",
+        "Two Writing Intensive (WI) courses required (max one per semester).",
+        "Environmental Electives: at least 1 from List A, at least 1 at 300-level.",
+        "ENVS 298, 391, 395, 398, 399 require SES approval.",
+        "300-level BIOL, CHEM, PHYS courses eligible as environmental electives with SES approval."
+      ],
+      "categories": [
+        {
+          "name": "Core Curriculum",
+          "description": "Required foundational courses (mix of 1- and 3-credit courses)",
+          "slots": 8,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "ENVS 137",
+              "required": true
+            },
+            {
+              "course": "ENVS 237",
+              "required": true
+            },
+            {
+              "course": "ENVS 238",
+              "required": true
+            },
+            {
+              "course": "ENVS 200",
+              "required": true
+            },
+            {
+              "course": "ENVS 203",
+              "required": true
+            },
+            {
+              "course": "ENVS 280",
+              "required": true
+            },
+            {
+              "course": "ENVS 286",
+              "required": true
+            },
+            {
+              "course": "PLSC 392",
+              "required": true
+            }
+          ],
+          "notes": "Actual credits: ENVS 137 (3), ENVS 237 (3), ENVS 238 (1), ENVS 200 (1), ENVS 203 (3), ENVS 280 (3), ENVS 286 (1), PLSC 392 (3) = 18 credits"
+        },
+        {
+          "name": "Justice and Ethics",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENVS 284",
+            "PHIL 287",
+            "THEO 204"
+          ]
+        },
+        {
+          "name": "Economics",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENVS 335",
+            "ECON 328"
+          ]
+        },
+        {
+          "name": "Engaged Learning",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENVS 226",
+            "ENVS 267",
+            "ENVS 273",
+            "ENVS 283",
+            "ENVS 340",
+            "ENVS 345",
+            "ENVS 350A",
+            "ENVS 350B",
+            "ENVS 350C",
+            "ENVS 350F",
+            "ENVS 391",
+            "ENVS 395"
+          ]
+        },
+        {
+          "name": "Capstone",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENVS 390",
+            "ENVS 391C",
+            "ENVS 395C"
+          ]
+        },
+        {
+          "name": "Society, Ethics, and Justice Electives",
+          "description": "Select two",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "COMM 101",
+            "COMM 260",
+            "COMM 277",
+            "COMM 306",
+            "COMM 322",
+            "ENGL 288",
+            "ENVS 204",
+            "ENVS 279",
+            "ENVS 284",
+            "ENVS 297",
+            "ENVS 298",
+            "ENVS 310",
+            "ENVS 311",
+            "ENVS 312",
+            "ENVS 313",
+            "ENVS 338",
+            "ENVS 350A",
+            "ENVS 350B",
+            "ENVS 350C",
+            "ENVS 350F",
+            "ENVS 383",
+            "ENVS 391",
+            "ENVS 395",
+            "ENVS 398",
+            "ENVS 399",
+            "PHIL 287",
+            "PSYC 277",
+            "SOCL 226",
+            "SOCL 252",
+            "SOCL 272",
+            "SOCL 276",
+            "SOCL 278",
+            "THEO 204",
+            "THEO 344"
+          ]
+        },
+        {
+          "name": "Policy, Economics, and Resource Management Elective",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ECON 328",
+            "ENVS 298",
+            "ENVS 300",
+            "ENVS 310",
+            "ENVS 311",
+            "ENVS 312",
+            "ENVS 313",
+            "ENVS 332",
+            "ENVS 333",
+            "ENVS 335",
+            "ENVS 336",
+            "ENVS 338",
+            "ENVS 351",
+            "ENVS 363",
+            "ENVS 364",
+            "ENVS 383",
+            "ENVS 384",
+            "ENVS 389",
+            "ENVS 391",
+            "ENVS 395",
+            "ENVS 398",
+            "ENVS 399",
+            "GLST 305",
+            "MGMT 201",
+            "PLSC 354"
+          ]
+        },
+        {
+          "name": "Methods and Analysis Elective",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ANTH 317",
+            "BIOL 335",
+            "COMM 231",
+            "COMM 234",
+            "COMM 260",
+            "COMM 277",
+            "COMM 363",
+            "ENVS 298",
+            "ENVS 327",
+            "ENVS 352",
+            "ENVS 353",
+            "ENVS 354",
+            "ENVS 380",
+            "ENVS 381",
+            "ENVS 382",
+            "ENVS 384",
+            "ENVS 388",
+            "ENVS 389",
+            "ENVS 391",
+            "ENVS 395",
+            "ENVS 398",
+            "ENVS 399",
+            "MARK 320",
+            "SOCL 206",
+            "SOCL 301",
+            "SOCL 302",
+            "STAT 203",
+            "STAT 303"
+          ]
+        },
+        {
+          "name": "Environmental Electives",
+          "description": "Select three: at least 1 from List A (science focus), at least 1 at 300-level",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ANTH 104",
+            "ANTH 303",
+            "COMM 260",
+            "ENVS 204",
+            "ENVS 207",
+            "ENVS 218",
+            "ENVS 223",
+            "ENVS 224",
+            "ENVS 226",
+            "ENVS 227R",
+            "ENVS 267",
+            "ENVS 273",
+            "ENVS 274",
+            "ENVS 278",
+            "ENVS 279",
+            "ENVS 283",
+            "ENVS 297",
+            "ENVS 298",
+            "ENVS 300",
+            "ENVS 301",
+            "ENVS 303",
+            "ENVS 310",
+            "ENVS 311",
+            "ENVS 312",
+            "ENVS 313",
+            "ENVS 319",
+            "ENVS 320",
+            "ENVS 322",
+            "ENVS 325",
+            "ENVS 326",
+            "ENVS 327",
+            "ENVS 330",
+            "ENVS 332",
+            "ENVS 333",
+            "ENVS 335",
+            "ENVS 336",
+            "ENVS 338",
+            "ENVS 340",
+            "ENVS 345",
+            "ENVS 350A",
+            "ENVS 350B",
+            "ENVS 350C",
+            "ENVS 350F",
+            "ENVS 352",
+            "ENVS 353",
+            "ENVS 354",
+            "ENVS 363",
+            "ENVS 364",
+            "ENVS 369",
+            "ENVS 380",
+            "ENVS 381",
+            "ENVS 382",
+            "ENVS 383",
+            "ENVS 384",
+            "ENVS 385",
+            "ENVS 387",
+            "ENVS 388",
+            "ENVS 389",
+            "ENVS 391",
+            "ENVS 395",
+            "ENVS 398",
+            "ENVS 399",
+            "ANTH 317",
+            "COMM 231",
+            "COMM 234",
+            "COMM 277",
+            "COMM 363",
+            "MARK 320",
+            "SOCL 206",
+            "SOCL 302"
+          ],
+          "notes": "Combines List A (science) and List B (policy/methods). At least 1 must be from List A, at least 1 at 300-level."
+        }
+      ]
+    },
+    {
+      "code": "ENVS-BA-EESG",
+      "name": "Environmental Economics & Sustainability: Governance (BA)",
+      "type": "major",
+      "department": "ENVS",
+      "total_credits": 60,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "core_waivers": [],
+      "notes": [
+        "School of Environmental Sustainability (SES), not College of Arts & Sciences.",
+        "Foreign language required: 102-level or above, or SES proficiency exam.",
+        "Two Writing Intensive (WI) courses required (max one per semester).",
+        "Total credits 60-61 depending on math choice (MATH 130 can be 3 or 4 credits)."
+      ],
+      "categories": [
+        {
+          "name": "Core Curriculum",
+          "description": "Required foundational courses",
+          "slots": 12,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "ENVS 137",
+              "required": true
+            },
+            {
+              "course": "ENVS 200",
+              "required": true
+            },
+            {
+              "course": "ENVS 237",
+              "required": true
+            },
+            {
+              "course": "ENVS 238",
+              "required": true
+            },
+            {
+              "course": "ENVS 280",
+              "required": true
+            },
+            {
+              "course": "ENVS 286",
+              "required": true
+            },
+            {
+              "course": "ENVS 283",
+              "required": true
+            },
+            {
+              "course": "ECON 201",
+              "required": true
+            },
+            {
+              "course": "ECON 202",
+              "required": true
+            },
+            {
+              "course": "ECON 303",
+              "required": true
+            },
+            {
+              "course": "ENVS 335",
+              "required": true
+            },
+            {
+              "course": "PLSC 392",
+              "required": true
+            }
+          ],
+          "notes": "Actual credits: ENVS 137 (3), ENVS 200 (1), ENVS 237 (3), ENVS 238 (1), ENVS 280 (3), ENVS 286 (1), ENVS 283 (3), ECON 201 (3), ECON 202 (3), ECON 303 (3), ENVS 335 (3), PLSC 392 (3) = 30 credits"
+        },
+        {
+          "name": "Mathematics",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "MATH 130",
+            "MATH 131",
+            "MATH 161"
+          ],
+          "notes": "MATH 130 may be 3-4 credits; MATH 131 and MATH 161 are 4 credits."
+        },
+        {
+          "name": "Statistics",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "STAT 103",
+            "ISSCM 241",
+            "ENVS 203"
+          ]
+        },
+        {
+          "name": "Justice and Ethics",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENVS 284",
+            "PHIL 287",
+            "THEO 204"
+          ]
+        },
+        {
+          "name": "Governance Concentration Required",
+          "description": "Both required",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "ECON 328",
+              "required": true
+            },
+            {
+              "course": "ENVS 310",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Capstone",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENVS 390",
+            "ENVS 391C",
+            "ENVS 395C"
+          ]
+        },
+        {
+          "name": "Governance Electives — List A",
+          "description": "Select two economics courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ECON 320",
+            "ECON 325",
+            "ECON 329",
+            "ECON 334",
+            "ECON 346"
+          ]
+        },
+        {
+          "name": "Governance Electives — List B",
+          "description": "Select two policy courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENVS 311",
+            "ENVS 312",
+            "ENVS 313",
+            "ENVS 327",
+            "ENVS 384"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "ENVS-BA-EESM",
+      "name": "Environmental Economics & Sustainability: Management (BA)",
+      "type": "major",
+      "department": "ENVS",
+      "total_credits": 60,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "core_waivers": [],
+      "notes": [
+        "School of Environmental Sustainability (SES), not College of Arts & Sciences.",
+        "Foreign language required: 102-level or above, or SES proficiency exam.",
+        "Two Writing Intensive (WI) courses required (max one per semester).",
+        "Total credits 60-61 depending on math choice."
+      ],
+      "categories": [
+        {
+          "name": "Core Curriculum",
+          "description": "Required foundational courses",
+          "slots": 12,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "ENVS 137",
+              "required": true
+            },
+            {
+              "course": "ENVS 200",
+              "required": true
+            },
+            {
+              "course": "ENVS 237",
+              "required": true
+            },
+            {
+              "course": "ENVS 238",
+              "required": true
+            },
+            {
+              "course": "ENVS 280",
+              "required": true
+            },
+            {
+              "course": "ENVS 286",
+              "required": true
+            },
+            {
+              "course": "ENVS 283",
+              "required": true
+            },
+            {
+              "course": "ECON 201",
+              "required": true
+            },
+            {
+              "course": "ECON 202",
+              "required": true
+            },
+            {
+              "course": "ECON 303",
+              "required": true
+            },
+            {
+              "course": "ENVS 335",
+              "required": true
+            },
+            {
+              "course": "PLSC 392",
+              "required": true
+            }
+          ],
+          "notes": "Actual credits: ENVS 137 (3), ENVS 200 (1), ENVS 237 (3), ENVS 238 (1), ENVS 280 (3), ENVS 286 (1), ENVS 283 (3), ECON 201 (3), ECON 202 (3), ECON 303 (3), ENVS 335 (3), PLSC 392 (3) = 30 credits"
+        },
+        {
+          "name": "Mathematics",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "MATH 130",
+            "MATH 131",
+            "MATH 161"
+          ],
+          "notes": "MATH 130 may be 3-4 credits; MATH 131 and MATH 161 are 4 credits."
+        },
+        {
+          "name": "Statistics",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "STAT 103",
+            "ISSCM 241",
+            "ENVS 203"
+          ]
+        },
+        {
+          "name": "Justice and Ethics",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENVS 284",
+            "PHIL 287",
+            "THEO 204"
+          ]
+        },
+        {
+          "name": "Management Concentration Required",
+          "description": "Both required",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "MGMT 201",
+              "required": true
+            },
+            {
+              "course": "ENVS 363",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Capstone",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENVS 390",
+            "ENVS 391C",
+            "ENVS 395C"
+          ]
+        },
+        {
+          "name": "Management Electives — List A",
+          "description": "Select two business/economics courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ECON 328",
+            "ECON 346",
+            "ECON 360",
+            "MARK 320",
+            "SCMG 346"
+          ]
+        },
+        {
+          "name": "Management Electives — List B",
+          "description": "Select two sustainability courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENVS 333",
+            "ENVS 336",
+            "ENVS 384"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "ENVS-BA-EP",
+      "name": "Environmental Policy (BA)",
+      "type": "major",
+      "department": "ENVS",
+      "total_credits": 57,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "core_waivers": [],
+      "notes": [
+        "School of Environmental Sustainability (SES), not College of Arts & Sciences.",
+        "Foreign language required: 102-level or above, or SES proficiency exam.",
+        "Two Writing Intensive (WI) courses required (max one per semester).",
+        "Shares foundational core with ENVS-BA but adds PLSC 101 and ENVS 310 as required."
+      ],
+      "categories": [
+        {
+          "name": "Core Curriculum",
+          "description": "Required foundational courses",
+          "slots": 10,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "ENVS 137",
+              "required": true
+            },
+            {
+              "course": "ENVS 237",
+              "required": true
+            },
+            {
+              "course": "ENVS 238",
+              "required": true
+            },
+            {
+              "course": "ENVS 200",
+              "required": true
+            },
+            {
+              "course": "ENVS 203",
+              "required": true
+            },
+            {
+              "course": "ENVS 280",
+              "required": true
+            },
+            {
+              "course": "ENVS 286",
+              "required": true
+            },
+            {
+              "course": "ENVS 310",
+              "required": true
+            },
+            {
+              "course": "PLSC 101",
+              "required": true
+            },
+            {
+              "course": "PLSC 392",
+              "required": true
+            }
+          ],
+          "notes": "Actual credits: ENVS 137 (3), ENVS 237 (3), ENVS 238 (1), ENVS 200 (1), ENVS 203 (3), ENVS 280 (3), ENVS 286 (1), ENVS 310 (3), PLSC 101 (3), PLSC 392 (3) = 24 credits"
+        },
+        {
+          "name": "Justice and Ethics",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENVS 284",
+            "PHIL 287",
+            "THEO 204"
+          ]
+        },
+        {
+          "name": "Economics",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENVS 335",
+            "ECON 328"
+          ]
+        },
+        {
+          "name": "Engaged Learning",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENVS 226",
+            "ENVS 267",
+            "ENVS 273",
+            "ENVS 283",
+            "ENVS 340",
+            "ENVS 345",
+            "ENVS 350A",
+            "ENVS 350B",
+            "ENVS 350C",
+            "ENVS 350F",
+            "ENVS 391",
+            "ENVS 395"
+          ]
+        },
+        {
+          "name": "Capstone",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENVS 390",
+            "ENVS 391C",
+            "ENVS 395C"
+          ]
+        },
+        {
+          "name": "Society, Ethics, and Justice Elective",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "COMM 101",
+            "COMM 260",
+            "COMM 277",
+            "COMM 306",
+            "COMM 322",
+            "COMM 379",
+            "ENGL 288",
+            "ENVS 204",
+            "ENVS 279",
+            "ENVS 284",
+            "ENVS 297",
+            "ENVS 298",
+            "ENVS 338",
+            "ENVS 350A",
+            "ENVS 350B",
+            "ENVS 350C",
+            "ENVS 350F",
+            "ENVS 383",
+            "ENVS 391",
+            "ENVS 395",
+            "ENVS 398",
+            "ENVS 399",
+            "PHIL 287",
+            "PSYC 277",
+            "SOCL 226",
+            "SOCL 252",
+            "SOCL 272",
+            "SOCL 276",
+            "SOCL 278",
+            "THEO 204",
+            "THEO 344"
+          ]
+        },
+        {
+          "name": "Policy, Economics, and Resource Management Electives",
+          "description": "Select two",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ECON 328",
+            "ENVS 298",
+            "ENVS 300",
+            "ENVS 311",
+            "ENVS 312",
+            "ENVS 313",
+            "ENVS 327",
+            "ENVS 333",
+            "ENVS 335",
+            "ENVS 336",
+            "ENVS 338",
+            "ENVS 363",
+            "ENVS 383",
+            "ENVS 384",
+            "ENVS 389",
+            "ENVS 391",
+            "ENVS 395",
+            "ENVS 398",
+            "ENVS 399",
+            "GLST 305",
+            "MGMT 201",
+            "PLSC 354"
+          ]
+        },
+        {
+          "name": "Methods and Analysis Elective",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ANTH 317",
+            "BIOL 335",
+            "COMM 231",
+            "COMM 234",
+            "COMM 260",
+            "COMM 277",
+            "COMM 363",
+            "ENVS 298",
+            "ENVS 327",
+            "ENVS 352",
+            "ENVS 353",
+            "ENVS 354",
+            "ENVS 380",
+            "ENVS 381",
+            "ENVS 382",
+            "ENVS 384",
+            "ENVS 389",
+            "ENVS 391",
+            "ENVS 395",
+            "ENVS 398",
+            "ENVS 399",
+            "MARK 320",
+            "SOCL 206",
+            "SOCL 301",
+            "SOCL 302",
+            "STAT 203",
+            "STAT 303"
+          ]
+        },
+        {
+          "name": "Environmental Electives",
+          "description": "Select two from combined List A/B",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ANTH 104",
+            "ANTH 303",
+            "COMM 260",
+            "ENVS 204",
+            "ENVS 207",
+            "ENVS 215",
+            "ENVS 218",
+            "ENVS 223",
+            "ENVS 224",
+            "ENVS 226",
+            "ENVS 227R",
+            "ENVS 267",
+            "ENVS 273",
+            "ENVS 274",
+            "ENVS 278",
+            "ENVS 279",
+            "ENVS 283",
+            "ENVS 297",
+            "ENVS 298",
+            "ENVS 300",
+            "ENVS 301",
+            "ENVS 303",
+            "ENVS 311",
+            "ENVS 312",
+            "ENVS 313",
+            "ENVS 320",
+            "ENVS 322",
+            "ENVS 323",
+            "ENVS 325",
+            "ENVS 326",
+            "ENVS 327",
+            "ENVS 330",
+            "ENVS 338",
+            "ENVS 340",
+            "ENVS 345",
+            "ENVS 350A",
+            "ENVS 350B",
+            "ENVS 350C",
+            "ENVS 350F",
+            "ENVS 351",
+            "ENVS 352",
+            "ENVS 353",
+            "ENVS 354",
+            "ENVS 369",
+            "ENVS 380",
+            "ENVS 381",
+            "ENVS 385",
+            "ENVS 387",
+            "ENVS 389",
+            "ENVS 391",
+            "ENVS 395",
+            "ENVS 398",
+            "ENVS 399"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "ENVS-BS",
+      "name": "Environmental Science (BS)",
+      "type": "major",
+      "department": "ENVS",
+      "total_credits": 66,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "core_waivers": [],
+      "notes": [
+        "School of Environmental Sustainability (SES), not College of Arts & Sciences.",
+        "Foreign language required: 102-level or above, or SES proficiency exam.",
+        "Two Writing Intensive (WI) courses required (max one per semester).",
+        "Total credits range 66-70 depending on concentration.",
+        "Five concentrations available: No Concentration (66 cr), Conservation & Restoration Ecology (67 cr), Environmental Health (69 cr), Food Systems & Sustainable Agriculture (66 cr), Climate & Energy (70 cr).",
+        "Modeled here as the base No Concentration path (66 credits). Concentration-specific requirements would need separate program codes.",
+        "Environmental Science electives: at least 3 of 5 must be 300-level or above.",
+        "300-level BIOL, CHEM, PHYS courses eligible as environmental science electives with SES approval."
+      ],
+      "categories": [
+        {
+          "name": "Science Core",
+          "description": "Required foundational science courses",
+          "slots": 13,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "BIOL 101",
+              "required": true
+            },
+            {
+              "course": "BIOL 111",
+              "required": true
+            },
+            {
+              "course": "CHEM 160",
+              "required": true
+            },
+            {
+              "course": "CHEM 161",
+              "required": true
+            },
+            {
+              "course": "ENVS 137",
+              "required": true
+            },
+            {
+              "course": "ENVS 200",
+              "required": true
+            },
+            {
+              "course": "ENVS 203",
+              "required": true
+            },
+            {
+              "course": "ENVS 274",
+              "required": true
+            },
+            {
+              "course": "ENVS 275",
+              "required": true
+            },
+            {
+              "course": "ENVS 276",
+              "required": true
+            },
+            {
+              "course": "ENVS 280",
+              "required": true
+            },
+            {
+              "course": "ENVS 286",
+              "required": true
+            },
+            {
+              "course": "PLSC 392",
+              "required": true
+            }
+          ],
+          "notes": "Actual credits: BIOL 101 (3), BIOL 111 (1), CHEM 160 (3), CHEM 161 (1), ENVS 137 (3), ENVS 200 (1), ENVS 203 (3), ENVS 274 (3), ENVS 275 (1), ENVS 276 (3), ENVS 280 (3), ENVS 286 (1), PLSC 392 (3) = 29 credits"
+        },
+        {
+          "name": "Biology Sequence",
+          "description": "Select one sequence (Biology for most paths; Physics for Climate & Energy)",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "BIOL 102",
+            "BIOL 112",
+            "PHYS 111",
+            "PHYS 111L"
+          ],
+          "notes": "BIOL 102 (3) + BIOL 112 (1) = 4 credits for most students. PHYS 111 (3) + PHYS 111L (1) = 4 credits for Climate & Energy."
+        },
+        {
+          "name": "Justice and Ethics",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENVS 284",
+            "PHIL 287",
+            "THEO 204"
+          ]
+        },
+        {
+          "name": "Economics",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENVS 335",
+            "ECON 328"
+          ]
+        },
+        {
+          "name": "Engaged Learning",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENVS 226",
+            "ENVS 267",
+            "ENVS 273",
+            "ENVS 283",
+            "ENVS 340",
+            "ENVS 345",
+            "ENVS 350A",
+            "ENVS 350C",
+            "ENVS 350F",
+            "ENVS 369",
+            "ENVS 391",
+            "ENVS 395"
+          ]
+        },
+        {
+          "name": "Capstone",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ENVS 390",
+            "ENVS 391C",
+            "ENVS 395C"
+          ]
+        },
+        {
+          "name": "Society, Ethics, and Justice Elective",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "COMM 101",
+            "COMM 277",
+            "COMM 306",
+            "COMM 322",
+            "COMM 379",
+            "ENGL 288",
+            "ENVS 204",
+            "ENVS 230",
+            "ENVS 260",
+            "ENVS 279",
+            "ENVS 284",
+            "ENVS 285",
+            "ENVS 297",
+            "ENVS 298",
+            "ENVS 338",
+            "ENVS 350A",
+            "ENVS 350C",
+            "ENVS 350F",
+            "ENVS 383",
+            "ENVS 391",
+            "ENVS 395",
+            "ENVS 398",
+            "ENVS 399",
+            "PHIL 287",
+            "PSYC 277",
+            "SOCL 226",
+            "SOCL 252",
+            "SOCL 272",
+            "SOCL 276",
+            "SOCL 278",
+            "THEO 204",
+            "THEO 344"
+          ]
+        },
+        {
+          "name": "Policy, Economics, and Resource Management Elective",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "COMM 379",
+            "ECON 328",
+            "ENVS 230",
+            "ENVS 298",
+            "ENVS 300",
+            "ENVS 310",
+            "ENVS 311",
+            "ENVS 312",
+            "ENVS 313",
+            "ENVS 316",
+            "ENVS 327",
+            "ENVS 333",
+            "ENVS 335",
+            "ENVS 336",
+            "ENVS 338",
+            "ENVS 351",
+            "ENVS 363",
+            "ENVS 383",
+            "ENVS 384",
+            "ENVS 389",
+            "ENVS 391",
+            "ENVS 395",
+            "ENVS 398",
+            "ENVS 399",
+            "GLST 305",
+            "MGMT 201",
+            "PLSC 354"
+          ]
+        },
+        {
+          "name": "Environmental Science Electives",
+          "description": "Select five; at least 3 must be 300-level or above",
+          "slots": 5,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ANTH 104",
+            "ANTH 303",
+            "ENVS 204",
+            "ENVS 207",
+            "ENVS 215",
+            "ENVS 218",
+            "ENVS 223",
+            "ENVS 224",
+            "ENVS 226",
+            "ENVS 267",
+            "ENVS 273",
+            "ENVS 278",
+            "ENVS 283",
+            "ENVS 298",
+            "ENVS 300",
+            "ENVS 301",
+            "ENVS 303",
+            "ENVS 320",
+            "ENVS 322",
+            "ENVS 323",
+            "ENVS 324",
+            "ENVS 325",
+            "ENVS 326",
+            "ENVS 327",
+            "ENVS 330",
+            "ENVS 338",
+            "ENVS 340",
+            "ENVS 345",
+            "ENVS 350A",
+            "ENVS 350C",
+            "ENVS 350F",
+            "ENVS 367",
+            "ENVS 369",
+            "ENVS 380",
+            "ENVS 381",
+            "ENVS 382",
+            "ENVS 383",
+            "ENVS 384",
+            "ENVS 385",
+            "ENVS 386",
+            "ENVS 387",
+            "ENVS 389",
+            "ENVS 391",
+            "ENVS 395",
+            "ENVS 398",
+            "ENVS 399"
+          ],
+          "notes": "At least 3 of 5 must be 300-level or above. BIOL, CHEM, PHYS 300-level courses also eligible with SES approval."
+        }
+      ]
+    },
+    {
+      "code": "BCHM-BA",
+      "name": "Biochemistry (BA)",
+      "type": "major",
+      "department": "CHEM",
+      "total_credits": 66,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "CHEM 361 Principles of Biochemistry does not count toward the BCHM-BA degree.",
+        "CHEM 300 Undergraduate Research is strongly recommended but not required.",
+        "CHEM 300 and CHEM 380 are required for departmental honors but do not count toward the 66-hour requirement.",
+        "Students must demonstrate math readiness via ACT/SAT or placement before registering for chemistry.",
+        "Must complete prerequisite math courses with grade of C- or better."
+      ],
+      "categories": [
+        {
+          "name": "Chemistry Core",
+          "description": "Required chemistry lecture and lab courses",
+          "slots": 11,
+          "credits_per_slot": null,
+          "total_credits": 31,
+          "eligible_courses": [
+            "CHEM 160",
+            "CHEM 161",
+            "CHEM 180",
+            "CHEM 181",
+            "CHEM 240",
+            "CHEM 242",
+            "CHEM 260",
+            "CHEM 272",
+            "CHEM 305",
+            "CHEM 306",
+            "CHEM 307",
+            "CHEM 370",
+            "CHEM 371"
+          ],
+          "notes": "All 13 courses required. CHEM 161/181/242/272/306 are lab components."
+        },
+        {
+          "name": "Biochemistry Focus Elective",
+          "description": "Select one biochemistry focus course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "CHEM 365",
+            "CHEM 385",
+            "CHEM 386",
+            "CHEM 387",
+            "CHEM 388"
+          ]
+        },
+        {
+          "name": "Biochemistry Elective",
+          "description": "Select one additional elective from chemistry or biology",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "CHEM 323",
+            "CHEM 365",
+            "CHEM 385",
+            "CHEM 386",
+            "CHEM 387",
+            "CHEM 388",
+            "CHEM 396",
+            "BIOL 335",
+            "BIOL 380",
+            "BIOL 382",
+            "BIOL 388",
+            "BIOL 389"
+          ]
+        },
+        {
+          "name": "Physics",
+          "description": "Required physics sequence with labs",
+          "slots": 4,
+          "credits_per_slot": null,
+          "total_credits": 8,
+          "eligible_courses": [
+            "PHYS 111",
+            "PHYS 111L",
+            "PHYS 112",
+            "PHYS 112L"
+          ],
+          "notes": "Complete lecture + lab for both semesters"
+        },
+        {
+          "name": "Mathematics",
+          "description": "Two-semester calculus sequence",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "MATH 131",
+            "MATH 132",
+            "MATH 161",
+            "MATH 162"
+          ],
+          "notes": "Take either MATH 131+132 (Applied) or MATH 161+162 (Calculus)"
+        },
+        {
+          "name": "Biology",
+          "description": "Required biology courses with labs",
+          "slots": 7,
+          "credits_per_slot": null,
+          "total_credits": 15,
+          "eligible_courses": [
+            "BIOL 101",
+            "BIOL 102",
+            "BIOL 111",
+            "BIOL 112",
+            "BIOL 251",
+            "BIOL 282",
+            "BIOL 283"
+          ],
+          "notes": "BIOL 111/112/283 are lab components (1 cr each)"
+        }
+      ]
+    },
+    {
+      "code": "BCHM-BS",
+      "name": "Biochemistry (BS)",
+      "type": "major",
+      "department": "CHEM",
+      "total_credits": 73,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "CHEM 361 Principles of Biochemistry does not count toward the BCHM-BS degree.",
+        "CHEM 300 and CHEM 380 are required for departmental honors but do not count toward the 73-hour requirement.",
+        "BS degree is ACS-accredited (American Chemical Society).",
+        "Students not placing in MATH 118 or higher cannot start Chemistry until MATH 117 is completed with C- or better."
+      ],
+      "categories": [
+        {
+          "name": "Chemistry Core",
+          "description": "Required chemistry lecture and lab courses",
+          "slots": 15,
+          "credits_per_slot": null,
+          "total_credits": 36,
+          "eligible_courses": [
+            "CHEM 160",
+            "CHEM 161",
+            "CHEM 180",
+            "CHEM 181",
+            "CHEM 240",
+            "CHEM 242",
+            "CHEM 260",
+            "CHEM 272",
+            "CHEM 305",
+            "CHEM 306",
+            "CHEM 307",
+            "CHEM 370",
+            "CHEM 371",
+            "CHEM 372",
+            "CHEM 373"
+          ],
+          "notes": "All 15 courses required. BS adds CHEM 372 and CHEM 373 (Biochemistry Labs I & II) compared to BA."
+        },
+        {
+          "name": "Biochemistry Focus Elective",
+          "description": "Select one biochemistry focus course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "CHEM 365",
+            "CHEM 385",
+            "CHEM 386",
+            "CHEM 387",
+            "CHEM 388"
+          ]
+        },
+        {
+          "name": "Biochemistry Elective",
+          "description": "Select one additional elective from chemistry or biology",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "CHEM 323",
+            "CHEM 365",
+            "CHEM 385",
+            "CHEM 386",
+            "CHEM 387",
+            "CHEM 388",
+            "CHEM 396",
+            "BIOL 380",
+            "BIOL 382",
+            "BIOL 388",
+            "BIOL 389"
+          ]
+        },
+        {
+          "name": "Physics",
+          "description": "Required physics sequence with labs",
+          "slots": 4,
+          "credits_per_slot": null,
+          "total_credits": 8,
+          "eligible_courses": [
+            "PHYS 111",
+            "PHYS 111L",
+            "PHYS 112",
+            "PHYS 112L"
+          ]
+        },
+        {
+          "name": "Mathematics",
+          "description": "Two-semester calculus plus statistics",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "MATH 131",
+            "MATH 132",
+            "MATH 161",
+            "MATH 162",
+            "STAT 203"
+          ],
+          "notes": "Take either MATH 131+132 or MATH 161+162, plus STAT 203. BS requires statistics unlike BA."
+        },
+        {
+          "name": "Biology",
+          "description": "Required biology courses with labs",
+          "slots": 7,
+          "credits_per_slot": null,
+          "total_credits": 12,
+          "eligible_courses": [
+            "BIOL 101",
+            "BIOL 102",
+            "BIOL 111",
+            "BIOL 112",
+            "BIOL 251",
+            "BIOL 282",
+            "BIOL 283"
+          ],
+          "notes": "BIOL 111/112/283 are lab components (1 cr each)"
+        }
+      ]
+    },
+    {
+      "code": "BIOL-BS",
+      "name": "Biology (BS)",
+      "type": "major",
+      "department": "BIOL",
+      "total_credits": 67,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "Students are allowed only TWO attempts to pass Biology courses with C- or better. Withdrawals (W) count as an attempt.",
+        "Transfer students must take minimum 20 credit hours in Biology at Loyola. No more than 18 transfer credits may apply.",
+        "At least 9 credits of biology electives must be at the 300 level.",
+        "At least 2 elective courses must include a laboratory component.",
+        "Maximum 2 credits of BIOL 296 count toward electives.",
+        "Maximum 3 total credits combining BIOL 396/396E/396M and BIOL 398/398E/398M.",
+        "Either BIOL 240/PSYC 240 or NEUR 101 may count, but not both."
+      ],
+      "categories": [
+        {
+          "name": "Biology Core",
+          "description": "Required biology lecture and lab courses",
+          "slots": 7,
+          "credits_per_slot": null,
+          "total_credits": 17,
+          "eligible_courses": [
+            "BIOL 101",
+            "BIOL 102",
+            "BIOL 111",
+            "BIOL 112",
+            "BIOL 251",
+            "BIOL 265",
+            "BIOL 282"
+          ],
+          "notes": "All 7 required. BIOL 111/112 are labs (1 cr each)."
+        },
+        {
+          "name": "Biology Core Lab Elective",
+          "description": "Select one additional 200-level lab",
+          "slots": 1,
+          "credits_per_slot": 1,
+          "eligible_courses": [
+            "BIOL 252",
+            "BIOL 266",
+            "BIOL 283"
+          ],
+          "notes": "Choose one: Cell Biology Lab, Ecology Lab, or Genetics Lab"
+        },
+        {
+          "name": "Biology Electives",
+          "description": "Select additional biology elective courses (19 credits total)",
+          "slots": 5,
+          "total_credits": 19,
+          "eligible_courses": [
+            "BIOL 205",
+            "BIOL 210",
+            "BIOL 215",
+            "BIOL 240",
+            "BIOL 242",
+            "BIOL 243",
+            "BIOL 246",
+            "BIOL 252",
+            "BIOL 266",
+            "BIOL 280",
+            "BIOL 281",
+            "BIOL 283",
+            "BIOL 284",
+            "BIOL 296",
+            "BIOL 302",
+            "BIOL 303",
+            "BIOL 310",
+            "BIOL 313",
+            "BIOL 315",
+            "BIOL 316",
+            "BIOL 319",
+            "BIOL 320",
+            "BIOL 323",
+            "BIOL 325",
+            "BIOL 326",
+            "BIOL 327",
+            "BIOL 335",
+            "BIOL 336",
+            "BIOL 337",
+            "BIOL 340",
+            "BIOL 341",
+            "BIOL 342",
+            "BIOL 346",
+            "BIOL 347",
+            "BIOL 348",
+            "BIOL 349",
+            "BIOL 353",
+            "BIOL 355",
+            "BIOL 359",
+            "BIOL 360",
+            "BIOL 363",
+            "BIOL 366",
+            "BIOL 366L",
+            "BIOL 367",
+            "BIOL 368",
+            "BIOL 370",
+            "BIOL 373",
+            "BIOL 375",
+            "BIOL 378",
+            "BIOL 385",
+            "BIOL 390",
+            "BIOL 394",
+            "BIOL 394E",
+            "BIOL 394M",
+            "BIOL 395L",
+            "BIOL 396",
+            "BIOL 396E",
+            "BIOL 396M",
+            "BIOL 397",
+            "BIOL 397E",
+            "BIOL 397M",
+            "BIOL 398",
+            "BIOL 398E",
+            "BIOL 398M",
+            "ANTH 246",
+            "ANTH 280",
+            "ANTH 281",
+            "ANTH 325",
+            "ANTH 326",
+            "ANTH 327",
+            "ANTH 346",
+            "ANTH 359",
+            "CHEM 361",
+            "ENVS 215",
+            "ENVS 267",
+            "ENVS 340",
+            "ENVS 345",
+            "ENVS 367",
+            "ENVS 369",
+            "NEUR 101",
+            "NEUR 300",
+            "NEUR 301",
+            "NEUR 302",
+            "PHYS 371",
+            "PSYC 240",
+            "PSYC 311",
+            "PSYC 382",
+            "PSYC 388",
+            "STAT 310",
+            "STAT 335",
+            "STAT 336",
+            "STAT 337"
+          ],
+          "notes": "At least 9 credits at 300-level. At least 2 courses must include a lab component."
+        },
+        {
+          "name": "Chemistry",
+          "description": "Required chemistry sequence (multiple track options)",
+          "slots": 4,
+          "total_credits": 8,
+          "eligible_courses": [
+            "CHEM 101",
+            "CHEM 102",
+            "CHEM 105",
+            "CHEM 106",
+            "CHEM 111",
+            "CHEM 112",
+            "CHEM 160",
+            "CHEM 161",
+            "CHEM 180",
+            "CHEM 181",
+            "CHEM 221",
+            "CHEM 222",
+            "CHEM 223",
+            "CHEM 224",
+            "CHEM 225",
+            "CHEM 226",
+            "CHEM 240",
+            "CHEM 241",
+            "CHEM 260",
+            "CHEM 261"
+          ],
+          "notes": "Multiple chemistry track options. Common path: CHEM 160+161, CHEM 180+181, CHEM 240+241, CHEM 260+261. Alternatives include CHEM 101/102/105/106 and CHEM 221-226 sequences."
+        },
+        {
+          "name": "Mathematics",
+          "description": "Two-semester calculus sequence",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "MATH 131",
+            "MATH 132",
+            "MATH 161",
+            "MATH 162"
+          ],
+          "notes": "Take either MATH 131+132 (Applied) or MATH 161+162 (Calculus)"
+        },
+        {
+          "name": "Physics",
+          "description": "Required physics sequence with labs",
+          "slots": 4,
+          "total_credits": 8,
+          "eligible_courses": [
+            "PHYS 111",
+            "PHYS 111L",
+            "PHYS 112",
+            "PHYS 112L",
+            "PHYS 121",
+            "PHYS 122",
+            "PHYS 125",
+            "PHYS 126"
+          ],
+          "notes": "Choose one Physics I lecture (PHYS 111/121/125) + PHYS 111L, and one Physics II lecture (PHYS 112/122/126) + PHYS 112L"
+        }
+      ]
+    },
+    {
+      "code": "BIOL-BS-ECOL",
+      "name": "Biology with Ecology Emphasis (BS)",
+      "type": "major",
+      "department": "BIOL",
+      "total_credits": 67,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "Students are allowed only TWO attempts to pass Biology courses with C- or better. Withdrawals (W) count as an attempt.",
+        "Transfer students must take minimum 20 credit hours in Biology at Loyola. No more than 18 transfer credits may apply.",
+        "At least 6 credits of biology electives must be at the 300 level.",
+        "At least 2 elective courses must include a laboratory component.",
+        "At least 2 electives must be designated as Ecology Electives.",
+        "Maximum 2 credits of BIOL 296 count toward electives.",
+        "Maximum 3 total credits of BIOL 396E or BIOL 398E (but not both) count toward degree.",
+        "Either BIOL 240/PSYC 240 or NEUR 101 may count, but not both."
+      ],
+      "categories": [
+        {
+          "name": "Biology Core",
+          "description": "Required biology courses including ecology and evolution focus",
+          "slots": 9,
+          "credits_per_slot": null,
+          "total_credits": 21,
+          "eligible_courses": [
+            "BIOL 101",
+            "BIOL 102",
+            "BIOL 111",
+            "BIOL 112",
+            "BIOL 251",
+            "BIOL 265",
+            "BIOL 266",
+            "BIOL 282",
+            "BIOL 319"
+          ],
+          "notes": "All 9 required. Ecology emphasis adds BIOL 266 (Ecology Lab) and BIOL 319 (Evolution) as required vs general BIOL-BS."
+        },
+        {
+          "name": "Biology Electives",
+          "description": "Select additional biology elective courses (16 credits total)",
+          "slots": 5,
+          "total_credits": 16,
+          "eligible_courses": [
+            "BIOL 205",
+            "BIOL 210",
+            "BIOL 215",
+            "BIOL 240",
+            "BIOL 242",
+            "BIOL 243",
+            "BIOL 246",
+            "BIOL 252",
+            "BIOL 280",
+            "BIOL 281",
+            "BIOL 283",
+            "BIOL 284",
+            "BIOL 296",
+            "BIOL 302",
+            "BIOL 303",
+            "BIOL 310",
+            "BIOL 313",
+            "BIOL 315",
+            "BIOL 316",
+            "BIOL 319",
+            "BIOL 320",
+            "BIOL 321",
+            "BIOL 323",
+            "BIOL 325",
+            "BIOL 326",
+            "BIOL 327",
+            "BIOL 328",
+            "BIOL 330",
+            "BIOL 335",
+            "BIOL 336",
+            "BIOL 337",
+            "BIOL 340",
+            "BIOL 341",
+            "BIOL 342",
+            "BIOL 344",
+            "BIOL 346",
+            "BIOL 347",
+            "BIOL 348",
+            "BIOL 349",
+            "BIOL 353",
+            "BIOL 355",
+            "BIOL 359",
+            "BIOL 360",
+            "BIOL 363",
+            "BIOL 366",
+            "BIOL 366L",
+            "BIOL 367",
+            "BIOL 368",
+            "BIOL 369",
+            "BIOL 370",
+            "BIOL 373",
+            "BIOL 375",
+            "BIOL 378",
+            "BIOL 385",
+            "BIOL 390",
+            "BIOL 394",
+            "BIOL 394E",
+            "BIOL 394M",
+            "BIOL 395",
+            "BIOL 395E",
+            "BIOL 395L",
+            "BIOL 395M",
+            "BIOL 396",
+            "BIOL 396E",
+            "BIOL 396M",
+            "BIOL 397",
+            "BIOL 397E",
+            "BIOL 397M",
+            "BIOL 398",
+            "BIOL 398E",
+            "BIOL 398M",
+            "BIOL 399E",
+            "ANTH 246",
+            "ANTH 280",
+            "ANTH 281",
+            "ANTH 325",
+            "ANTH 326",
+            "ANTH 327",
+            "ANTH 346",
+            "ANTH 359",
+            "CHEM 361",
+            "ENVS 215",
+            "ENVS 267",
+            "ENVS 340",
+            "ENVS 345",
+            "ENVS 367",
+            "ENVS 369",
+            "NEUR 101",
+            "NEUR 300",
+            "NEUR 301",
+            "NEUR 302",
+            "PHYS 371",
+            "PSYC 240",
+            "PSYC 311",
+            "PSYC 382",
+            "PSYC 388",
+            "STAT 310",
+            "STAT 335",
+            "STAT 336",
+            "STAT 337"
+          ],
+          "notes": "At least 6 credits at 300-level. At least 2 courses with lab. At least 2 must be Ecology Electives."
+        },
+        {
+          "name": "Ecology Electives",
+          "description": "At least 2 of the biology electives must come from this ecology-designated list",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "is_subset_constraint": true,
+          "eligible_courses": [
+            "BIOL 205",
+            "BIOL 316",
+            "BIOL 320",
+            "BIOL 321",
+            "BIOL 327",
+            "BIOL 328",
+            "BIOL 330",
+            "BIOL 344",
+            "BIOL 353",
+            "BIOL 355",
+            "BIOL 360",
+            "BIOL 363",
+            "BIOL 368",
+            "BIOL 369",
+            "BIOL 370",
+            "BIOL 375",
+            "BIOL 394E",
+            "BIOL 395E",
+            "BIOL 396E",
+            "BIOL 397E",
+            "BIOL 398E",
+            "BIOL 399E",
+            "ANTH 246",
+            "ANTH 281",
+            "ANTH 325",
+            "ENVS 215",
+            "ENVS 267",
+            "ENVS 340",
+            "ENVS 345",
+            "ENVS 367",
+            "ENVS 369",
+            "STAT 335"
+          ],
+          "notes": "These count toward the Biology Electives total but must be ecology-designated. Subset constraint, not additional credits."
+        },
+        {
+          "name": "Chemistry",
+          "description": "Required chemistry sequence",
+          "slots": 4,
+          "total_credits": 12,
+          "eligible_courses": [
+            "CHEM 101",
+            "CHEM 105",
+            "CHEM 111",
+            "CHEM 160",
+            "CHEM 161",
+            "CHEM 180",
+            "CHEM 181",
+            "CHEM 221",
+            "CHEM 223",
+            "CHEM 225",
+            "CHEM 240",
+            "CHEM 241",
+            "CHEM 222",
+            "CHEM 224",
+            "CHEM 226"
+          ],
+          "notes": "Three semesters of chemistry with labs. Common path: CHEM 160+161, CHEM 180+181, CHEM 240+241."
+        },
+        {
+          "name": "Mathematics",
+          "description": "Two-semester calculus sequence",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "MATH 131",
+            "MATH 132",
+            "MATH 161",
+            "MATH 162"
+          ],
+          "notes": "Take either MATH 131+132 (Applied) or MATH 161+162 (Calculus)"
+        },
+        {
+          "name": "Physics",
+          "description": "Required physics sequence with labs",
+          "slots": 4,
+          "total_credits": 8,
+          "eligible_courses": [
+            "PHYS 111",
+            "PHYS 111L",
+            "PHYS 112",
+            "PHYS 112L",
+            "PHYS 121",
+            "PHYS 122",
+            "PHYS 125",
+            "PHYS 126"
+          ],
+          "notes": "Choose one Physics I lecture (PHYS 111/121/125) + PHYS 111L, and one Physics II lecture (PHYS 112/122/126) + PHYS 112L"
+        }
+      ]
+    },
+    {
+      "code": "BIOL-BS-MOLB",
+      "name": "Biology with Molecular Biology Emphasis (BS)",
+      "type": "major",
+      "department": "BIOL",
+      "total_credits": 67,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "Students are allowed only TWO attempts to pass Biology courses with C- or better. Withdrawals (W) count as an attempt.",
+        "Transfer students must take minimum 20 credit hours in Biology at Loyola. No more than 18 transfer credits may apply.",
+        "Maximum 3 total credits of BIOL 396M or BIOL 398M (but not both) count toward degree.",
+        "Designed for students preparing for health professions, research, or graduate programs in molecular biology."
+      ],
+      "categories": [
+        {
+          "name": "Biology Core",
+          "description": "Required biology courses with molecular emphasis",
+          "slots": 9,
+          "credits_per_slot": null,
+          "total_credits": 21,
+          "eligible_courses": [
+            "BIOL 101",
+            "BIOL 102",
+            "BIOL 111",
+            "BIOL 112",
+            "BIOL 251",
+            "BIOL 265",
+            "BIOL 282",
+            "BIOL 283",
+            "BIOL 366"
+          ],
+          "notes": "All 9 required. Molecular emphasis requires BIOL 283 (Genetics Lab) and BIOL 366 (Cell Physiology & Biochemistry) as required vs general BIOL-BS."
+        },
+        {
+          "name": "Molecular Elective: Select One Lecture",
+          "description": "Select one molecular biology lecture course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "BIOL 382",
+            "BIOL 387",
+            "BIOL 388"
+          ],
+          "notes": "Choose one: Molecular Genetics, Genomics, or Bioinformatics"
+        },
+        {
+          "name": "Molecular Elective: Select One Lab/Research",
+          "description": "Select one molecular biology lab or research experience",
+          "slots": 1,
+          "credits_per_slot": null,
+          "eligible_courses": [
+            "BIOL 366L",
+            "BIOL 390",
+            "BIOL 396M",
+            "BIOL 397M",
+            "BIOL 398M"
+          ],
+          "notes": "1-4 credits depending on course chosen"
+        },
+        {
+          "name": "Biology Electives (Open)",
+          "description": "Select additional biology elective courses to reach 16 total elective credits",
+          "slots": 3,
+          "total_credits": 12,
+          "eligible_courses": [
+            "BIOL 252",
+            "BIOL 296",
+            "BIOL 302",
+            "BIOL 307",
+            "BIOL 315",
+            "BIOL 317",
+            "BIOL 318",
+            "BIOL 319",
+            "BIOL 344",
+            "BIOL 351",
+            "BIOL 352",
+            "BIOL 366L",
+            "BIOL 377",
+            "BIOL 380",
+            "BIOL 381",
+            "BIOL 382",
+            "BIOL 383",
+            "BIOL 384",
+            "BIOL 387",
+            "BIOL 388",
+            "BIOL 390",
+            "BIOL 392",
+            "BIOL 394M",
+            "BIOL 395M",
+            "BIOL 396M",
+            "BIOL 397M",
+            "BIOL 398M",
+            "BIOL 399M",
+            "PHYS 371"
+          ],
+          "notes": "At least one must include a laboratory component. Combined with the two molecular elective slots above, total elective credits = 16."
+        },
+        {
+          "name": "Chemistry",
+          "description": "Required chemistry sequence (four semesters with labs)",
+          "slots": 4,
+          "total_credits": 8,
+          "eligible_courses": [
+            "CHEM 101",
+            "CHEM 102",
+            "CHEM 105",
+            "CHEM 106",
+            "CHEM 111",
+            "CHEM 112",
+            "CHEM 160",
+            "CHEM 161",
+            "CHEM 180",
+            "CHEM 181",
+            "CHEM 221",
+            "CHEM 222",
+            "CHEM 223",
+            "CHEM 224",
+            "CHEM 225",
+            "CHEM 226",
+            "CHEM 240",
+            "CHEM 241",
+            "CHEM 260",
+            "CHEM 261"
+          ],
+          "notes": "Four semesters of chemistry with labs. Common path: CHEM 160+161, CHEM 180+181, CHEM 240+241, CHEM 260+261."
+        },
+        {
+          "name": "Mathematics",
+          "description": "Two-semester calculus sequence",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "MATH 131",
+            "MATH 132",
+            "MATH 161",
+            "MATH 162"
+          ],
+          "notes": "Take either MATH 131+132 (Applied) or MATH 161+162 (Calculus)"
+        },
+        {
+          "name": "Physics",
+          "description": "Required physics sequence with labs",
+          "slots": 4,
+          "total_credits": 8,
+          "eligible_courses": [
+            "PHYS 111",
+            "PHYS 111L",
+            "PHYS 112",
+            "PHYS 112L",
+            "PHYS 121",
+            "PHYS 122",
+            "PHYS 125",
+            "PHYS 126"
+          ],
+          "notes": "Choose one Physics I lecture (PHYS 111/121/125) + PHYS 111L, and one Physics II lecture (PHYS 112/122/126) + PHYS 112L"
+        }
+      ]
+    },
+    {
+      "code": "FRSC-BS",
+      "name": "Forensic Science (BS)",
+      "type": "major",
+      "department": "FRSC",
+      "total_credits": 86,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "Program is fully accredited by The Forensic Education Programs Accreditation Commission (FEPAC).",
+        "Students not placing in MATH 118 or higher cannot start Chemistry until MATH 117 is completed with C- or better.",
+        "BIOL 366L, FRSC 390, and FRSC 394 satisfy the Engaged Learning requirement.",
+        "Total credits range 86-88 depending on capstone selection."
+      ],
+      "categories": [
+        {
+          "name": "Laboratory Science: Biology",
+          "description": "Required biology courses with labs",
+          "slots": 7,
+          "credits_per_slot": null,
+          "total_credits": 15,
+          "eligible_courses": [
+            "BIOL 101",
+            "BIOL 102",
+            "BIOL 111",
+            "BIOL 112",
+            "BIOL 282",
+            "BIOL 283",
+            "BIOL 366",
+            "BIOL 366L"
+          ],
+          "notes": "BIOL 366 is cross-listed with CHEM 361. BIOL 366L is Cell Physiology & Biochemistry Lab (3 cr)."
+        },
+        {
+          "name": "Laboratory Science: Chemistry",
+          "description": "Required chemistry courses with labs",
+          "slots": 9,
+          "credits_per_slot": null,
+          "total_credits": 20,
+          "eligible_courses": [
+            "CHEM 160",
+            "CHEM 161",
+            "CHEM 180",
+            "CHEM 181",
+            "CHEM 240",
+            "CHEM 241",
+            "CHEM 260",
+            "CHEM 272",
+            "CHEM 280"
+          ],
+          "notes": "CHEM 280 is Environmental & Chemical Analysis (3 cr). CHEM 272 is Analytical Chemistry Lab (2 cr)."
+        },
+        {
+          "name": "Laboratory Science: Physics",
+          "description": "Required physics sequence with labs",
+          "slots": 4,
+          "credits_per_slot": null,
+          "total_credits": 8,
+          "eligible_courses": [
+            "PHYS 111",
+            "PHYS 111L",
+            "PHYS 112",
+            "PHYS 112L"
+          ]
+        },
+        {
+          "name": "Forensic Science and Criminal Justice",
+          "description": "Required forensic science core and criminal justice course",
+          "slots": 8,
+          "credits_per_slot": null,
+          "total_credits": 28,
+          "eligible_courses": [
+            "CJC 101",
+            "FRSC 340",
+            "FRSC 341",
+            "FRSC 342",
+            "FRSC 343",
+            "FRSC 350",
+            "FRSC 350L",
+            "FRSC 360",
+            "FRSC 360L",
+            "FRSC 370",
+            "FRSC 370L"
+          ],
+          "notes": "FRSC 350/350L = Pattern Evidence I + Lab. FRSC 360/360L = Forensic Drug Chemistry I + Lab. FRSC 370/370L = Forensic Biology + Lab."
+        },
+        {
+          "name": "Forensic Capstone",
+          "description": "Select one capstone option",
+          "slots": 1,
+          "credits_per_slot": null,
+          "eligible_courses": [
+            "FRSC 361",
+            "FRSC 361L",
+            "FRSC 371",
+            "ANTH 396"
+          ],
+          "notes": "Choose one: FRSC 361+361L (Forensic Toxicology I + Lab), FRSC 371 (Forensic Molecular Biology), or ANTH 396 (Internship, requires ANTH 326 prereq). 3-5 credits depending on choice."
+        },
+        {
+          "name": "Ancillary: Mathematics and Statistics",
+          "description": "Required math and statistics courses",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "MATH 131",
+            "MATH 132",
+            "BIOL 335",
+            "STAT 335"
+          ],
+          "notes": "MATH 131 + MATH 132 (Applied Calculus I & II) plus BIOL 335 or STAT 335 (Intro to Biostatistics)"
+        }
+      ]
+    },
+    {
+      "code": "NEUR-BS-CB",
+      "name": "Cognitive and Behavioral Neuroscience (BS)",
+      "type": "major",
+      "department": "NEUR",
+      "total_credits": 74,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "Interdisciplinary program spanning Biology and Psychology departments.",
+        "Independent research must be approved by the NRCB Director for specialty lab credit.",
+        "Students may conduct research in psychology, biology, or other departments with director approval.",
+        "Total credits range 74-76 depending on course selections."
+      ],
+      "categories": [
+        {
+          "name": "Biology Foundation",
+          "description": "Required biology courses with labs",
+          "slots": 6,
+          "credits_per_slot": null,
+          "total_credits": 15,
+          "eligible_courses": [
+            "BIOL 101",
+            "BIOL 102",
+            "BIOL 111",
+            "BIOL 112",
+            "BIOL 251",
+            "BIOL 252",
+            "BIOL 282",
+            "BIOL 283"
+          ],
+          "notes": "BIOL 101+111, BIOL 102+112, BIOL 251+252, BIOL 282 required. Choose either BIOL 252 (Cell Bio Lab) or BIOL 283 (Genetics Lab) for lab component."
+        },
+        {
+          "name": "Statistics",
+          "description": "Select one statistics course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "BIOL 335",
+            "STAT 335",
+            "PSYC 304"
+          ]
+        },
+        {
+          "name": "Mathematics",
+          "description": "One semester of calculus",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "MATH 131",
+            "MATH 161"
+          ]
+        },
+        {
+          "name": "Psychology Foundation",
+          "description": "Required general psychology",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "PSYC 101"
+          ]
+        },
+        {
+          "name": "Chemistry",
+          "description": "Two semesters of chemistry with labs",
+          "slots": 4,
+          "total_credits": 8,
+          "eligible_courses": [
+            "CHEM 101",
+            "CHEM 102",
+            "CHEM 105",
+            "CHEM 106",
+            "CHEM 111",
+            "CHEM 112",
+            "CHEM 160",
+            "CHEM 161",
+            "CHEM 180",
+            "CHEM 181"
+          ],
+          "notes": "Two semesters required. Common paths: CHEM 160+161 then CHEM 180+181, or CHEM 101+111 then CHEM 102+112."
+        },
+        {
+          "name": "Physics",
+          "description": "Two semesters of physics with labs",
+          "slots": 4,
+          "total_credits": 8,
+          "eligible_courses": [
+            "PHYS 111",
+            "PHYS 111L",
+            "PHYS 112",
+            "PHYS 112L",
+            "PHYS 121",
+            "PHYS 122",
+            "PHYS 125",
+            "PHYS 125L",
+            "PHYS 126",
+            "PHYS 126L",
+            "PHYS 126F"
+          ]
+        },
+        {
+          "name": "Neuroscience Foundations",
+          "description": "Three required neuroscience core courses",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "NEUR 101",
+            "BIOL 362",
+            "PSYC 382",
+            "BIOL 284"
+          ],
+          "notes": "All three required: NEUR 101, BIOL 362 (Neurobiology), and PSYC 382/BIOL 284 (Behavioral & Cognitive Neuroscience)"
+        },
+        {
+          "name": "Cognitive/Behavioral Specialty",
+          "description": "Required specialty area courses",
+          "slots": 3,
+          "credits_per_slot": null,
+          "total_credits": 10,
+          "eligible_courses": [
+            "NEUR 300",
+            "BIOL 303",
+            "PSYC 306",
+            "COMP 150",
+            "COMP 170",
+            "COMP 180",
+            "DSCI 101"
+          ],
+          "notes": "NEUR 300/BIOL 303 (Seminar, 1 cr) + PSYC 306 (Research Methods, 3 cr) + one computing course (COMP 150/170/180 or DSCI 101, 3 cr)"
+        },
+        {
+          "name": "CB Lecture Electives",
+          "description": "Select three cognitive/behavioral neuroscience lecture courses",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "BIOL 320",
+            "BIOL 351",
+            "BIOL 352",
+            "BIOL 357",
+            "BIOL 395",
+            "PSYC 240",
+            "BIOL 240",
+            "PSYC 251",
+            "PSYC 332",
+            "PSYC 350",
+            "PSYC 352",
+            "PSYC 355",
+            "PHIL 355",
+            "PSYC 378",
+            "PSYC 383",
+            "COMP 386"
+          ]
+        },
+        {
+          "name": "CB Lab Electives",
+          "description": "Select two cognitive/behavioral neuroscience lab courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "BIOL 395L",
+            "NEUR 301",
+            "BIOL 373",
+            "PSYC 388",
+            "PSYC 311",
+            "BIOL 313",
+            "PSYC 312",
+            "PSYC 313",
+            "PSYC 314",
+            "PSYC 316",
+            "PSYC 384",
+            "COMP 389",
+            "BIOL 396",
+            "PSYC 369",
+            "PSYC 370",
+            "PSYC 397"
+          ],
+          "notes": "Independent research (BIOL 396, PSYC 369/370/397) may substitute with NRCB Director approval."
+        },
+        {
+          "name": "Capstone",
+          "description": "Required capstone seminar",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "PSYC 387"
+          ],
+          "notes": "Seminar in Behavioral and Cognitive Neurosciences"
+        }
+      ]
+    },
+    {
+      "code": "NEUR-BS-MC",
+      "name": "Molecular and Cellular Neuroscience (BS)",
+      "type": "major",
+      "department": "NEUR",
+      "total_credits": 68,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "Interdisciplinary program spanning Biology and Chemistry departments.",
+        "Independent research with molecular/cellular focus in biology labs can qualify as specialty lab credit via BIOL 396 or BIOL 398.",
+        "Focuses on genetic, biochemical, and electrophysiological underpinnings of nervous system development, function, and pathology."
+      ],
+      "categories": [
+        {
+          "name": "Biology Foundation",
+          "description": "Required biology courses with labs",
+          "slots": 6,
+          "credits_per_slot": null,
+          "total_credits": 15,
+          "eligible_courses": [
+            "BIOL 101",
+            "BIOL 102",
+            "BIOL 111",
+            "BIOL 112",
+            "BIOL 251",
+            "BIOL 252",
+            "BIOL 282",
+            "BIOL 283"
+          ],
+          "notes": "BIOL 101+111, BIOL 102+112, BIOL 251, BIOL 282 required. Choose either BIOL 252 (Cell Bio Lab) or BIOL 283 (Genetics Lab)."
+        },
+        {
+          "name": "Statistics",
+          "description": "Select one statistics course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "BIOL 335",
+            "STAT 335",
+            "PSYC 304"
+          ]
+        },
+        {
+          "name": "Mathematics",
+          "description": "One semester of calculus",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "MATH 131",
+            "MATH 161"
+          ]
+        },
+        {
+          "name": "Psychology Foundation",
+          "description": "Required general psychology",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "PSYC 101"
+          ]
+        },
+        {
+          "name": "Chemistry (First Year)",
+          "description": "First year chemistry with labs",
+          "slots": 4,
+          "total_credits": 8,
+          "eligible_courses": [
+            "CHEM 101",
+            "CHEM 105",
+            "CHEM 111",
+            "CHEM 112",
+            "CHEM 160",
+            "CHEM 161",
+            "CHEM 180",
+            "CHEM 181",
+            "CHEM 221",
+            "CHEM 223"
+          ],
+          "notes": "Two semesters of general/introductory chemistry. Common path: CHEM 160+161 then CHEM 180+181."
+        },
+        {
+          "name": "Chemistry (Second Year)",
+          "description": "Additional year of chemistry for MC track",
+          "slots": 3,
+          "total_credits": 8,
+          "eligible_courses": [
+            "CHEM 102",
+            "CHEM 106",
+            "CHEM 112",
+            "CHEM 222",
+            "CHEM 224",
+            "CHEM 240",
+            "CHEM 260"
+          ],
+          "notes": "MC track requires an additional year of chemistry beyond CB track. Common path: CHEM 240 + CHEM 260, or CHEM 222 + CHEM 102/106."
+        },
+        {
+          "name": "Physics",
+          "description": "Two semesters of physics with labs",
+          "slots": 4,
+          "total_credits": 8,
+          "eligible_courses": [
+            "PHYS 111",
+            "PHYS 111L",
+            "PHYS 112",
+            "PHYS 112L",
+            "PHYS 121",
+            "PHYS 122",
+            "PHYS 125",
+            "PHYS 125L",
+            "PHYS 126",
+            "PHYS 126L",
+            "PHYS 126F"
+          ]
+        },
+        {
+          "name": "Neuroscience Foundations",
+          "description": "Three required neuroscience core courses",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "NEUR 101",
+            "BIOL 362",
+            "PSYC 382",
+            "BIOL 284"
+          ],
+          "notes": "All three required: NEUR 101, BIOL 362 (Neurobiology), and PSYC 382/BIOL 284 (Behavioral & Cognitive Neuroscience)"
+        },
+        {
+          "name": "MC Lecture Electives",
+          "description": "Select three molecular/cellular neuroscience lecture courses",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "BIOL 307",
+            "BIOL 351",
+            "BIOL 352",
+            "BIOL 357",
+            "BIOL 358",
+            "BIOL 381",
+            "BIOL 382",
+            "BIOL 395",
+            "CHEM 361",
+            "BIOL 366",
+            "CHEM 370",
+            "NEUR 300",
+            "PSYC 240",
+            "BIOL 240",
+            "PSYC 378",
+            "PSYC 383",
+            "COMP 386"
+          ]
+        },
+        {
+          "name": "MC Lab Electives",
+          "description": "Select two molecular/cellular neuroscience lab courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "BIOL 252",
+            "BIOL 283",
+            "BIOL 315",
+            "BIOL 366L",
+            "CHEM 372",
+            "BIOL 367",
+            "BIOL 390",
+            "BIOL 395L",
+            "NEUR 301",
+            "BIOL 373",
+            "PSYC 388",
+            "PSYC 311",
+            "BIOL 313",
+            "PSYC 316",
+            "PSYC 384",
+            "COMP 389",
+            "BIOL 396",
+            "BIOL 398"
+          ],
+          "notes": "Independent research (BIOL 396, BIOL 398 with molecular/cellular focus) may substitute."
+        },
+        {
+          "name": "Capstone",
+          "description": "Required capstone seminar",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "BIOL 376",
+            "BIOL 358"
+          ],
+          "notes": "Seminar in Molecular/Cellular Neuroscience. BIOL 358 (Developmental Neurobiology) is an alternative."
+        }
+      ]
+    },
+    {
+      "code": "COMP-BS",
+      "name": "Computer Science (BS)",
+      "type": "major",
+      "department": "COMP",
+      "total_credits": 63,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "core_waivers": [],
+      "notes": [
+        "Credits never can be double-counted for different categories of major requirements.",
+        "COMP 163 may be substituted with MATH 201.",
+        "STAT 203 may be substituted with MATH 212.",
+        "Extra credits from MATH 161/162 may apply toward CS Free Electives with director permission.",
+        "AP CS Principles (4-5) earns COMP 150 credit; AP CS A (4-5) earns COMP 170 credit.",
+        "Computing majors/minors generally cannot be combined except with CCFR-MINR.",
+        "61-63 credits depending on calculus sequence chosen."
+      ],
+      "categories": [
+        {
+          "name": "Mathematics",
+          "description": "Choose one calculus sequence",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "MATH 131",
+            "MATH 132",
+            "MATH 161",
+            "MATH 162"
+          ],
+          "notes": "Take MATH 131+132 (Applied Calculus) OR MATH 161+162 (Calculus). Extra credits from MATH 161/162 may apply toward free electives."
+        },
+        {
+          "name": "Core Computer Science",
+          "description": "All required",
+          "slots": 11,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "COMP 141",
+              "required": true
+            },
+            {
+              "course": "COMP 163",
+              "required": true,
+              "alternatives": [
+                "MATH 201"
+              ]
+            },
+            {
+              "course": "COMP 170",
+              "required": true
+            },
+            {
+              "course": "COMP 264",
+              "required": true
+            },
+            {
+              "course": "COMP 271",
+              "required": true
+            },
+            {
+              "course": "COMP 272",
+              "required": true
+            },
+            {
+              "course": "COMP 310",
+              "required": true
+            },
+            {
+              "course": "COMP 317",
+              "required": true
+            },
+            {
+              "course": "COMP 363",
+              "required": true
+            },
+            {
+              "course": "COMP 371",
+              "required": true
+            },
+            {
+              "course": "STAT 203",
+              "required": true,
+              "alternatives": [
+                "MATH 212"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Restricted Electives",
+          "description": "Select three courses (9 credits)",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "COMP 301",
+            "COMP 313",
+            "COMP 330",
+            "COMP 332",
+            "COMP 339",
+            "COMP 341",
+            "COMP 343",
+            "COMP 353",
+            "COMP 364",
+            "COMP 370",
+            "COMP 379"
+          ]
+        },
+        {
+          "name": "Practicum/Capstone",
+          "description": "Select 6 credits from practicum options",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "COMP 312",
+            "COMP 390",
+            "COMP 391",
+            "COMP 398"
+          ],
+          "notes": "COMP 390 max 3 credits total. COMP 391 and COMP 398 usually limited to 6 credits each."
+        },
+        {
+          "name": "300-Level Electives",
+          "description": "Any COMP 300-level course",
+          "slots": 1,
+          "credits_per_slot": 4,
+          "eligible_courses": "ANY_COMP_300_PLUS",
+          "notes": "4 credits of any COMP 300-level course."
+        },
+        {
+          "name": "Free Elective",
+          "description": "Select one course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "COMP 125",
+            "COMP 150",
+            "ANY_COMP_300_PLUS"
+          ],
+          "notes": "Any COMP 300-level course, COMP 125, or COMP 150."
+        }
+      ]
+    },
+    {
+      "code": "CYBR-BS",
+      "name": "Cybersecurity (BS)",
+      "type": "major",
+      "department": "COMP",
+      "total_credits": 62,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "core_waivers": [],
+      "notes": [
+        "Credits never can be double-counted for different categories of major requirements.",
+        "COMP 163 may be substituted with MATH 201.",
+        "AP CS Principles (4-5) earns COMP 150 credit; AP CS A (4-5) earns COMP 170 credit.",
+        "Computing majors/minors generally cannot be combined except with CCFR-MINR.",
+        "61-62 credits depending on calculus course chosen."
+      ],
+      "categories": [
+        {
+          "name": "Mathematics",
+          "description": "Choose one calculus course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "MATH 131",
+            "MATH 161"
+          ],
+          "notes": "MATH 131 (3 cr) or MATH 161 (4 cr). Extra credit from MATH 161 may apply toward electives."
+        },
+        {
+          "name": "Core Technical Requirements",
+          "description": "All required",
+          "slots": 14,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "COMP 141",
+              "required": true
+            },
+            {
+              "course": "COMP 163",
+              "required": true,
+              "alternatives": [
+                "MATH 201"
+              ]
+            },
+            {
+              "course": "COMP 170",
+              "required": true
+            },
+            {
+              "course": "COMP 264",
+              "required": true
+            },
+            {
+              "course": "COMP 271",
+              "required": true
+            },
+            {
+              "course": "COMP 301",
+              "required": true
+            },
+            {
+              "course": "COMP 310",
+              "required": true
+            },
+            {
+              "course": "COMP 317",
+              "required": true
+            },
+            {
+              "course": "COMP 340",
+              "required": true
+            },
+            {
+              "course": "COMP 343",
+              "required": true
+            },
+            {
+              "course": "COMP 347",
+              "required": true
+            },
+            {
+              "course": "COMP 348",
+              "required": true
+            },
+            {
+              "course": "COMP 349",
+              "required": true
+            },
+            {
+              "course": "COMP 352",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Practicum/Capstone",
+          "description": "Select 6 credits from practicum options",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "COMP 312",
+            "COMP 344",
+            "COMP 390",
+            "COMP 391",
+            "COMP 398"
+          ],
+          "notes": "COMP 390 max 3 credits. COMP 391 and COMP 398 typically capped at 6 each."
+        },
+        {
+          "name": "Restricted Electives",
+          "description": "Select 7 credits",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "CJC 354",
+            "COMP 272",
+            "ANY_COMP_300_PLUS"
+          ],
+          "notes": "7 credits from CJC 354, COMP 272, or any COMP 300-level courses."
+        },
+        {
+          "name": "Free Elective",
+          "description": "Select one course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "COMP 125",
+            "COMP 150",
+            "ANY_COMP_300_PLUS"
+          ],
+          "notes": "COMP 125, COMP 150, or any COMP 300-level 3-credit course."
+        }
+      ]
+    },
+    {
+      "code": "DSCI-BS",
+      "name": "Data Science (BS)",
+      "type": "major",
+      "department": "DSCI",
+      "total_credits": 59,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "core_waivers": [],
+      "notes": [
+        "Interdepartmental program spanning Mathematics/Statistics and Computer Science.",
+        "STAT electives exclude STAT 335 and STAT 337.",
+        "COMP electives exclude COMP 391.",
+        "DSCI 399 internship requires coordinator approval."
+      ],
+      "categories": [
+        {
+          "name": "Math Requirements",
+          "description": "All required",
+          "slots": 3,
+          "credits_per_slot": 4,
+          "eligible_courses_fixed": [
+            {
+              "course": "MATH 161",
+              "required": true
+            },
+            {
+              "course": "MATH 162",
+              "required": true
+            },
+            {
+              "course": "MATH 212",
+              "required": true
+            }
+          ],
+          "notes": "MATH 161 and MATH 162 are 4 credits each; MATH 212 is 3 credits. Total 11 credits."
+        },
+        {
+          "name": "Statistics Core",
+          "description": "All required",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "STAT 203",
+              "required": true
+            },
+            {
+              "course": "STAT 308",
+              "required": true
+            },
+            {
+              "course": "STAT 310",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Statistics Electives",
+          "description": "Two STAT 300-level courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": "ANY_STAT_300_PLUS",
+          "notes": "Any STAT 300-level course except STAT 335 and STAT 337."
+        },
+        {
+          "name": "Computer Science Core",
+          "description": "All required",
+          "slots": 4,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "COMP 141",
+              "required": true
+            },
+            {
+              "course": "COMP 215",
+              "required": true,
+              "alternatives": [
+                "MATH 215"
+              ]
+            },
+            {
+              "course": "COMP 231",
+              "required": true
+            },
+            {
+              "course": "COMP 353",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Computer Science Electives",
+          "description": "Two COMP 300-level courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": "ANY_COMP_300_PLUS",
+          "notes": "Any COMP 300-level course except COMP 391."
+        },
+        {
+          "name": "Data Science Core",
+          "description": "Required data science courses",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "COMP 317",
+              "required": true
+            },
+            {
+              "course": "DSCI 101",
+              "required": true
+            },
+            {
+              "course": "COMP 358",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Machine Learning / Predictive Analytics",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "STAT 338",
+            "COMP 379"
+          ]
+        },
+        {
+          "name": "Capstone",
+          "description": "Select one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "DSCI 399",
+            "STAT 370"
+          ],
+          "notes": "DSCI 399 requires coordinator approval."
+        }
+      ]
+    },
+    {
+      "code": "SWEN-BS",
+      "name": "Software Engineering (BS)",
+      "type": "major",
+      "department": "COMP",
+      "total_credits": 61,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "core_waivers": [],
+      "notes": [
+        "Credits never can be double-counted for different categories of major requirements.",
+        "COMP 163 may be substituted with MATH 201.",
+        "AP CS Principles (4-5) earns COMP 150 credit; AP CS A (4-5) earns COMP 170 credit.",
+        "Computing majors/minors generally cannot be combined except with CCFR-MINR.",
+        "Statistics requirement has multiple options across departments."
+      ],
+      "categories": [
+        {
+          "name": "Mathematics",
+          "description": "Choose one calculus course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "MATH 131",
+            "MATH 161"
+          ],
+          "notes": "MATH 131 (3 cr) or MATH 161 (4 cr). Extra credit from MATH 161 may apply toward free electives."
+        },
+        {
+          "name": "Statistics",
+          "description": "Choose one statistics course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ISSCM 241",
+            "PSYC 304",
+            "STAT 103",
+            "STAT 203"
+          ]
+        },
+        {
+          "name": "Core Computer Science",
+          "description": "All required",
+          "slots": 9,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "COMP 141",
+              "required": true
+            },
+            {
+              "course": "COMP 163",
+              "required": true,
+              "alternatives": [
+                "MATH 201"
+              ]
+            },
+            {
+              "course": "COMP 170",
+              "required": true
+            },
+            {
+              "course": "COMP 264",
+              "required": true
+            },
+            {
+              "course": "COMP 271",
+              "required": true
+            },
+            {
+              "course": "COMP 272",
+              "required": true
+            },
+            {
+              "course": "COMP 313",
+              "required": true
+            },
+            {
+              "course": "COMP 317",
+              "required": true
+            },
+            {
+              "course": "COMP 330",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Software Engineering Restricted Electives",
+          "description": "Select three courses (9 credits)",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "COMP 332",
+            "COMP 335",
+            "COMP 370",
+            "COMP 371",
+            "COMP 373",
+            "COMP 382"
+          ]
+        },
+        {
+          "name": "Practicum/Capstone",
+          "description": "Select 6 credits from practicum options",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "COMP 312",
+            "COMP 390",
+            "COMP 391",
+            "COMP 398"
+          ],
+          "notes": "COMP 390 max 3 credits. COMP 391 and COMP 398 typically capped at 6 each."
+        },
+        {
+          "name": "300-Level Electives",
+          "description": "Any COMP 300-level courses",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses": "ANY_COMP_300_PLUS",
+          "notes": "10 credits of any COMP 300-level courses. Modeled as 3 slots + 1 extra credit."
+        },
+        {
+          "name": "Free Elective",
+          "description": "Select one course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "COMP 125",
+            "COMP 150",
+            "ANY_COMP_300_PLUS"
+          ],
+          "notes": "COMP 125, COMP 150, or any COMP 300-level course."
+        }
+      ]
+    },
+    {
+      "code": "INFT-BS",
+      "name": "Information Technology (BS)",
+      "type": "major",
+      "department": "COMP",
+      "total_credits": 49,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "core_waivers": [],
+      "notes": [
+        "Credits never can be double-counted for different categories of major requirements.",
+        "Some COMP 300-level electives require COMP 271 as prerequisite.",
+        "COMP 264 and COMP 271 are alternatives — choose one.",
+        "COMP 377 and ISSCM 349 are alternatives for project management.",
+        "No IT-BA exists in Arts & Sciences; BA/MS pathway is through School of Continuing and Professional Studies."
+      ],
+      "categories": [
+        {
+          "name": "Statistics",
+          "description": "Choose one statistics course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "STAT 103",
+            "STAT 203",
+            "ISSCM 241",
+            "PSYC 304"
+          ]
+        },
+        {
+          "name": "Discrete Mathematics",
+          "description": "Choose one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "COMP 163",
+            "MATH 201"
+          ]
+        },
+        {
+          "name": "Core Computing",
+          "description": "All required",
+          "slots": 7,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "COMP 141",
+              "required": true
+            },
+            {
+              "course": "COMP 170",
+              "required": true
+            },
+            {
+              "course": "COMP 251",
+              "required": true
+            },
+            {
+              "course": "COMP 264",
+              "required": true,
+              "alternatives": [
+                "COMP 271"
+              ]
+            },
+            {
+              "course": "COMP 301",
+              "required": true
+            },
+            {
+              "course": "COMP 317",
+              "required": true
+            },
+            {
+              "course": "COMP 377",
+              "required": true,
+              "alternatives": [
+                "ISSCM 349"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Database/Advanced Electives",
+          "description": "Select two courses (6 credits)",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "COMP 305",
+            "COMP 306",
+            "COMP 343",
+            "COMP 353"
+          ]
+        },
+        {
+          "name": "Practicum/Capstone",
+          "description": "Select 6 credits from practicum options",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "COMP 312",
+            "COMP 390",
+            "COMP 391",
+            "COMP 398"
+          ],
+          "notes": "COMP 390 max 3 credits."
+        },
+        {
+          "name": "Electives",
+          "description": "Select approximately 10 credits from approved list",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "COMP 125",
+            "COMP 150",
+            "COMP 250",
+            "COMP 272",
+            "ENGL 210",
+            "MGMT 318",
+            "MGMT 320",
+            "MGMT 335",
+            "MGMT 360",
+            "ENTR 201",
+            "ENTR 311",
+            "ENTR 313",
+            "ENTR 345",
+            "ENTR 390",
+            "ISSCM 393",
+            "ANY_COMP_300_PLUS"
+          ],
+          "notes": "10 credits from approved list including business, entrepreneurship, and COMP courses. Modeled as 3 slots + 1 extra credit."
+        }
+      ]
+    },
+    {
+      "code": "MATH-BS",
+      "name": "Mathematics (BS)",
+      "type": "major",
+      "department": "MATH",
+      "total_credits": 51,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "core_waivers": [
+        "Quantitative",
+        "Scientific"
+      ],
+      "notes": [
+        "MATH 215 and COMP 170 are alternatives for the programming requirement.",
+        "STAT 203 and MATH 304/STAT 304 are alternatives for the probability/stats requirement.",
+        "Modern Algebra sequence: MATH 313 + one of MATH 314 or MATH 315.",
+        "Analysis sequence: MATH 351 + one of MATH 352 or MATH 353.",
+        "Science requirement: 2 lab science courses from approved list."
+      ],
+      "categories": [
+        {
+          "name": "Foundational Calculus",
+          "description": "All required",
+          "slots": 3,
+          "credits_per_slot": 4,
+          "eligible_courses_fixed": [
+            {
+              "course": "MATH 161",
+              "required": true
+            },
+            {
+              "course": "MATH 162",
+              "required": true
+            },
+            {
+              "course": "MATH 263",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Foundational Core",
+          "description": "All required",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "MATH 201",
+              "required": true
+            },
+            {
+              "course": "MATH 212",
+              "required": true
+            },
+            {
+              "course": "MATH 264",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Programming",
+          "description": "Choose one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "MATH 215",
+            "COMP 170"
+          ]
+        },
+        {
+          "name": "Probability/Statistics",
+          "description": "Choose one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "STAT 203",
+            "MATH 304",
+            "STAT 304"
+          ]
+        },
+        {
+          "name": "Modern Algebra Sequence",
+          "description": "MATH 313 plus one of MATH 314 or MATH 315",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "MATH 313",
+              "required": true
+            }
+          ],
+          "eligible_courses": [
+            "MATH 314",
+            "MATH 315"
+          ],
+          "notes": "Must take MATH 313 and then one of MATH 314 or MATH 315."
+        },
+        {
+          "name": "Analysis Sequence",
+          "description": "MATH 351 plus one of MATH 352 or MATH 353",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "MATH 351",
+              "required": true
+            }
+          ],
+          "eligible_courses": [
+            "MATH 352",
+            "MATH 353"
+          ],
+          "notes": "Must take MATH 351 and then one of MATH 352 or MATH 353."
+        },
+        {
+          "name": "Upper-Division Math Electives",
+          "description": "Two 300-level MATH electives",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": "ANY_MATH_300_PLUS",
+          "notes": "Any MATH 300-level course not already used."
+        },
+        {
+          "name": "Science Requirement",
+          "description": "Two lab science courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ANTH 101",
+            "ANTH 103",
+            "BIOL 101",
+            "BIOL 102",
+            "CHEM 101",
+            "CHEM 102",
+            "CHEM 160",
+            "CHEM 180",
+            "ENVS 101",
+            "ENVS 218",
+            "ENVS 224",
+            "PHYS 121",
+            "PHYS 122"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "MATH-BS-APPL",
+      "name": "Applied Mathematics (BS)",
+      "type": "major",
+      "department": "MATH",
+      "total_credits": 58,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "core_waivers": [
+        "Quantitative",
+        "Scientific"
+      ],
+      "notes": [
+        "55-58 credits depending on programming sequence chosen.",
+        "Programming Option A: COMP 170 + COMP 271 + COMP 272 (9 credits).",
+        "Programming Option B: MATH 215 + COMP 231 (6 credits).",
+        "Probability/Stats Option A: MATH 304 + MATH 305.",
+        "Probability/Stats Option B: STAT 203 + STAT 308.",
+        "Minimum 21 credit hours must be completed at Loyola.",
+        "Physics I with lab is required."
+      ],
+      "categories": [
+        {
+          "name": "Foundational Calculus",
+          "description": "All required",
+          "slots": 3,
+          "credits_per_slot": 4,
+          "eligible_courses_fixed": [
+            {
+              "course": "MATH 161",
+              "required": true
+            },
+            {
+              "course": "MATH 162",
+              "required": true
+            },
+            {
+              "course": "MATH 263",
+              "required": true
+            }
+          ],
+          "notes": "MATH 162A and MATH 263A are acceptable alternatives."
+        },
+        {
+          "name": "Foundational Core",
+          "description": "All required",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "MATH 201",
+              "required": true
+            },
+            {
+              "course": "MATH 212",
+              "required": true
+            },
+            {
+              "course": "MATH 264",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Physics",
+          "description": "Required",
+          "slots": 1,
+          "credits_per_slot": 4,
+          "eligible_courses_fixed": [
+            {
+              "course": "PHYS 121",
+              "required": true
+            }
+          ],
+          "notes": "Includes PHYS 111L lab (1 credit). Total 4 credits."
+        },
+        {
+          "name": "Programming Sequence",
+          "description": "Choose one sequence",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "COMP 170",
+            "COMP 271",
+            "COMP 272",
+            "MATH 215",
+            "COMP 231"
+          ],
+          "notes": "Option A: COMP 170 + COMP 271 + COMP 272 (9 cr, 3 slots). Option B: MATH 215 + COMP 231 (6 cr, 2 slots)."
+        },
+        {
+          "name": "Additional Science",
+          "description": "Select one lab science course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ANTH 101",
+            "BIOL 101",
+            "BIOL 102",
+            "CHEM 160",
+            "ENVS 101",
+            "PHYS 122"
+          ]
+        },
+        {
+          "name": "Probability and Statistics",
+          "description": "Choose one two-course sequence",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "MATH 304",
+            "MATH 305",
+            "STAT 203",
+            "STAT 308"
+          ],
+          "notes": "Option A: MATH 304 + MATH 305. Option B: STAT 203 + STAT 308."
+        },
+        {
+          "name": "Required Upper-Level",
+          "description": "Both required",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "MATH 309",
+              "required": true
+            },
+            {
+              "course": "MATH 356",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Applied Math Electives A",
+          "description": "Select two courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "MATH 318",
+            "MATH 331",
+            "MATH 345",
+            "MATH 358",
+            "MATH 360",
+            "MATH 365",
+            "MATH 366",
+            "MATH 388",
+            "STAT 321",
+            "STAT 388"
+          ]
+        },
+        {
+          "name": "Applied Math Elective B",
+          "description": "One 300-level MATH or approved STAT course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": "ANY_MATH_300_PLUS",
+          "notes": "One 300-level MATH course or approved 300-level STAT course."
+        }
+      ]
+    },
+    {
+      "code": "MATH-BS-COMP",
+      "name": "Mathematics and Computer Science (BS)",
+      "type": "major",
+      "department": "MATH",
+      "total_credits": 60,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "core_waivers": [
+        "Quantitative"
+      ],
+      "notes": [
+        "Interdepartmental program spanning Mathematics and Computer Science.",
+        "STAT 203 and MATH 304/STAT 304 are alternatives for the probability/stats requirement.",
+        "CS electives can include BIOL 388, MATH 328, MATH 331, and STAT 321 in addition to COMP 300-level."
+      ],
+      "categories": [
+        {
+          "name": "Mathematics Core",
+          "description": "All required",
+          "slots": 8,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "MATH 161",
+              "required": true
+            },
+            {
+              "course": "MATH 162",
+              "required": true
+            },
+            {
+              "course": "MATH 201",
+              "required": true
+            },
+            {
+              "course": "MATH 212",
+              "required": true
+            },
+            {
+              "course": "MATH 263",
+              "required": true
+            },
+            {
+              "course": "MATH 264",
+              "required": true
+            },
+            {
+              "course": "MATH 313",
+              "required": true
+            },
+            {
+              "course": "MATH 351",
+              "required": true
+            }
+          ],
+          "notes": "MATH 161, 162, and 263 are 4 credits each. Others are 3 credits. Total 27 credits."
+        },
+        {
+          "name": "Probability/Statistics",
+          "description": "Choose one",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "STAT 203",
+            "MATH 304",
+            "STAT 304"
+          ]
+        },
+        {
+          "name": "Math Electives",
+          "description": "Select two 300-level MATH courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "MATH 309",
+            "MATH 314",
+            "MATH 315",
+            "MATH 318",
+            "MATH 331",
+            "MATH 352",
+            "MATH 353",
+            "MATH 356",
+            "MATH 358",
+            "MATH 365",
+            "MATH 366",
+            "MATH 386"
+          ]
+        },
+        {
+          "name": "Computer Science Core",
+          "description": "All required",
+          "slots": 6,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "COMP 141",
+              "required": true
+            },
+            {
+              "course": "COMP 170",
+              "required": true
+            },
+            {
+              "course": "COMP 264",
+              "required": true
+            },
+            {
+              "course": "COMP 271",
+              "required": true
+            },
+            {
+              "course": "COMP 272",
+              "required": true
+            },
+            {
+              "course": "COMP 363",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "CS Electives",
+          "description": "Select two courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "BIOL 388",
+            "MATH 328",
+            "MATH 331",
+            "STAT 321",
+            "ANY_COMP_300_PLUS"
+          ],
+          "notes": "Any COMP 300-level course, or BIOL 388, MATH 328, MATH 331, STAT 321."
+        }
+      ]
+    },
+    {
+      "code": "STAT-BS",
+      "name": "Statistics (BS)",
+      "type": "major",
+      "department": "STAT",
+      "total_credits": 48,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "core_waivers": [
+        "Quantitative",
+        "Scientific"
+      ],
+      "notes": [
+        "STAT 203 and STAT 335 are alternatives for the intro statistics requirement.",
+        "STAT 307 is designated as the capstone course.",
+        "Science requirement: 2 lab science courses from approved list."
+      ],
+      "categories": [
+        {
+          "name": "Core Mathematics",
+          "description": "All required",
+          "slots": 3,
+          "credits_per_slot": 4,
+          "eligible_courses_fixed": [
+            {
+              "course": "MATH 161",
+              "required": true
+            },
+            {
+              "course": "MATH 162",
+              "required": true
+            },
+            {
+              "course": "MATH 263",
+              "required": true
+            }
+          ],
+          "notes": "MATH 212 (3 credits) is also required. Total 15 credits."
+        },
+        {
+          "name": "Linear Algebra",
+          "description": "Required",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "MATH 212",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Core Statistics",
+          "description": "All required",
+          "slots": 5,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "STAT 203",
+              "required": true,
+              "alternatives": [
+                "STAT 335"
+              ]
+            },
+            {
+              "course": "STAT 303",
+              "required": true
+            },
+            {
+              "course": "STAT 304",
+              "required": true
+            },
+            {
+              "course": "STAT 305",
+              "required": true
+            },
+            {
+              "course": "STAT 308",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Capstone",
+          "description": "Required capstone course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "STAT 307",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Science Requirement",
+          "description": "Two lab science courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ANTH 101",
+            "ANTH 103",
+            "BIOL 101",
+            "BIOL 102",
+            "CHEM 101",
+            "CHEM 102",
+            "CHEM 160",
+            "CHEM 180",
+            "ENVS 101",
+            "ENVS 218",
+            "ENVS 224",
+            "PHYS 121",
+            "PHYS 122"
+          ]
+        },
+        {
+          "name": "Statistics Electives",
+          "description": "Select three courses",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "STAT 306",
+            "STAT 310",
+            "STAT 311",
+            "STAT 321",
+            "STAT 336",
+            "STAT 337",
+            "STAT 338",
+            "STAT 344",
+            "STAT 351",
+            "STAT 370",
+            "STAT 388"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "INFT-BA",
+      "name": "Information Technology (BA)",
+      "type": "major",
+      "department": "CPST",
+      "total_credits": 39,
+      "unique_credits_required": 21,
+      "double_dip_policy": "SCPS_DEFAULT",
+      "core_waivers": [],
+      "notes": [
+        "This is a School of Continuing and Professional Studies (SCPS) program, not College of Arts & Sciences.",
+        "Available through BA/MS accelerated pathway.",
+        "Uses CPST (Continuing Professional Studies Technology) course codes.",
+        "120 total credits for degree including general education.",
+        "No standalone BA catalog page exists — sourced from BA/MS dual degree page."
+      ],
+      "categories": [
+        {
+          "name": "Computing Foundation",
+          "description": "All required",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "COMP 170",
+              "required": true
+            },
+            {
+              "course": "COMP 251",
+              "required": true
+            },
+            {
+              "course": "COMP 271",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Ethics & Statistics",
+          "description": "All required",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "COMP 317",
+              "required": true
+            },
+            {
+              "course": "STAT 103",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Professional Studies Core",
+          "description": "All required CPST courses",
+          "slots": 8,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "CPST 250",
+              "required": true
+            },
+            {
+              "course": "CPST 291",
+              "required": true
+            },
+            {
+              "course": "CPST 310",
+              "required": true
+            },
+            {
+              "course": "CPST 325",
+              "required": true
+            },
+            {
+              "course": "CPST 342",
+              "required": true
+            },
+            {
+              "course": "CPST 343",
+              "required": true
+            },
+            {
+              "course": "CPST 345",
+              "required": true
+            },
+            {
+              "course": "CPST 349",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "code": "ENGR-BS-BME",
+      "name": "Engineering with Biomedical Engineering Specialization (BS)",
+      "type": "major",
+      "department": "ENGR",
+      "total_credits": 86,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "core_waivers": [],
+      "notes": [
+        "129 total credit hours for degree including general education.",
+        "86 credits in engineering + math/science requirements.",
+        "Strict four-year sequencing with heavy prerequisite chains.",
+        "Capstone design is a two-semester sequence (ENGR 381 + ENGR 391).",
+        "Requires PHYS 112L lab separately from PHYS 122 lecture."
+      ],
+      "categories": [
+        {
+          "name": "Engineering Design",
+          "description": "All required",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "ENGR 101",
+              "required": true
+            },
+            {
+              "course": "ENGR 201",
+              "required": true
+            }
+          ],
+          "notes": "ENGR 101 is 4 credits; ENGR 201 is 3 credits. Total 7 credits."
+        },
+        {
+          "name": "Engineering Core",
+          "description": "All required",
+          "slots": 6,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "ENGR 102",
+              "required": true
+            },
+            {
+              "course": "ENGR 321",
+              "required": true
+            },
+            {
+              "course": "ENGR 322",
+              "required": true
+            },
+            {
+              "course": "ENGR 323",
+              "required": true
+            },
+            {
+              "course": "ENGR 324",
+              "required": true
+            },
+            {
+              "course": "ENGR 325",
+              "required": true
+            }
+          ],
+          "notes": "ENGR 102 is 1 credit; ENGR 321 is 2 credits; ENGR 324L (1 cr) included with ENGR 324. Total 16 credits."
+        },
+        {
+          "name": "Engineering Systems",
+          "description": "All required",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "ENGR 311",
+              "required": true
+            },
+            {
+              "course": "ENGR 312",
+              "required": true
+            },
+            {
+              "course": "ENGR 313",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Biomedical Engineering Specialization",
+          "description": "All required",
+          "slots": 6,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "ENGR 341",
+              "required": true
+            },
+            {
+              "course": "ENGR 341L",
+              "required": true
+            },
+            {
+              "course": "ENGR 342",
+              "required": true
+            },
+            {
+              "course": "ENGR 343",
+              "required": true
+            },
+            {
+              "course": "ENGR 381",
+              "required": true
+            },
+            {
+              "course": "ENGR 391",
+              "required": true
+            }
+          ],
+          "notes": "ENGR 341L is 1 credit; ENGR 381 and ENGR 391 are 4 credits each. Total 18 credits."
+        },
+        {
+          "name": "Math & Science",
+          "description": "All required",
+          "slots": 10,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "BIOL 101",
+              "required": true
+            },
+            {
+              "course": "BIOL 111",
+              "required": true
+            },
+            {
+              "course": "CHEM 171",
+              "required": true
+            },
+            {
+              "course": "CHEM 173",
+              "required": true
+            },
+            {
+              "course": "COMP 170",
+              "required": true
+            },
+            {
+              "course": "MATH 161",
+              "required": true
+            },
+            {
+              "course": "MATH 162",
+              "required": true
+            },
+            {
+              "course": "MATH 263",
+              "required": true
+            },
+            {
+              "course": "MATH 266",
+              "required": true
+            },
+            {
+              "course": "STAT 203",
+              "required": true
+            }
+          ],
+          "notes": "Also requires PHYS 121 (3 cr), PHYS 122 (3 cr), and PHYS 112L (1 cr). Total 29 credits."
+        },
+        {
+          "name": "Physics",
+          "description": "All required",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "PHYS 121",
+              "required": true
+            },
+            {
+              "course": "PHYS 122",
+              "required": true
+            }
+          ],
+          "notes": "PHYS 112L (1 cr) is also required. Total 7 credits."
+        }
+      ]
+    },
+    {
+      "code": "ENGR-BS-CPE",
+      "name": "Engineering with Computer Engineering Specialization (BS)",
+      "type": "major",
+      "department": "ENGR",
+      "total_credits": 86,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "core_waivers": [],
+      "notes": [
+        "131 total credit hours for degree including general education.",
+        "Strict four-year sequencing with heavy prerequisite chains.",
+        "Capstone design is a two-semester sequence (ENGR 382 + ENGR 392).",
+        "Requires PHYS 112L lab separately from PHYS 122 lecture."
+      ],
+      "categories": [
+        {
+          "name": "Engineering Design",
+          "description": "All required",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "ENGR 101",
+              "required": true
+            },
+            {
+              "course": "ENGR 201",
+              "required": true
+            }
+          ],
+          "notes": "ENGR 101 is 4 credits; ENGR 201 is 3 credits. Total 7 credits."
+        },
+        {
+          "name": "Engineering Core",
+          "description": "All required",
+          "slots": 6,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "ENGR 102",
+              "required": true
+            },
+            {
+              "course": "ENGR 321",
+              "required": true
+            },
+            {
+              "course": "ENGR 322",
+              "required": true
+            },
+            {
+              "course": "ENGR 323",
+              "required": true
+            },
+            {
+              "course": "ENGR 324",
+              "required": true
+            },
+            {
+              "course": "ENGR 325",
+              "required": true
+            }
+          ],
+          "notes": "ENGR 102 is 1 credit; ENGR 321 is 2 credits; ENGR 324L (1 cr) included. Total 16 credits."
+        },
+        {
+          "name": "Engineering Systems",
+          "description": "All required",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "ENGR 311",
+              "required": true
+            },
+            {
+              "course": "ENGR 312",
+              "required": true
+            },
+            {
+              "course": "ENGR 313",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Computer Engineering Specialization",
+          "description": "All required",
+          "slots": 6,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "ENGR 351",
+              "required": true
+            },
+            {
+              "course": "ENGR 351L",
+              "required": true
+            },
+            {
+              "course": "ENGR 352",
+              "required": true
+            },
+            {
+              "course": "ENGR 353",
+              "required": true
+            },
+            {
+              "course": "ENGR 382",
+              "required": true
+            },
+            {
+              "course": "ENGR 392",
+              "required": true
+            }
+          ],
+          "notes": "ENGR 351L is 1 credit; ENGR 382 and ENGR 392 are 4 credits each. Total 19 credits."
+        },
+        {
+          "name": "Math & Science",
+          "description": "All required",
+          "slots": 10,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "BIOL 101",
+              "required": true
+            },
+            {
+              "course": "BIOL 111",
+              "required": true
+            },
+            {
+              "course": "CHEM 171",
+              "required": true
+            },
+            {
+              "course": "CHEM 173",
+              "required": true
+            },
+            {
+              "course": "COMP 170",
+              "required": true
+            },
+            {
+              "course": "MATH 161",
+              "required": true
+            },
+            {
+              "course": "MATH 162",
+              "required": true
+            },
+            {
+              "course": "MATH 263",
+              "required": true
+            },
+            {
+              "course": "MATH 266",
+              "required": true
+            },
+            {
+              "course": "STAT 203",
+              "required": true
+            }
+          ],
+          "notes": "Total 29 credits (variable credit courses). Also requires PHYS 121, PHYS 122, PHYS 112L."
+        },
+        {
+          "name": "Physics",
+          "description": "All required",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "PHYS 121",
+              "required": true
+            },
+            {
+              "course": "PHYS 122",
+              "required": true
+            }
+          ],
+          "notes": "PHYS 112L (1 cr) is also required. Total 7 credits."
+        }
+      ]
+    },
+    {
+      "code": "ENGR-BS-ENE",
+      "name": "Engineering with Environmental Engineering Specialization (BS)",
+      "type": "major",
+      "department": "ENGR",
+      "total_credits": 86,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "core_waivers": [],
+      "notes": [
+        "129 total credit hours for degree including general education.",
+        "Strict four-year sequencing with heavy prerequisite chains.",
+        "Capstone design is a two-semester sequence (ENGR 383 + ENGR 393).",
+        "Requires PHYS 112L lab separately from PHYS 122 lecture."
+      ],
+      "categories": [
+        {
+          "name": "Engineering Design",
+          "description": "All required",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "ENGR 101",
+              "required": true
+            },
+            {
+              "course": "ENGR 201",
+              "required": true
+            }
+          ],
+          "notes": "ENGR 101 is 4 credits; ENGR 201 is 3 credits. Total 7 credits."
+        },
+        {
+          "name": "Engineering Core",
+          "description": "All required",
+          "slots": 6,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "ENGR 102",
+              "required": true
+            },
+            {
+              "course": "ENGR 321",
+              "required": true
+            },
+            {
+              "course": "ENGR 322",
+              "required": true
+            },
+            {
+              "course": "ENGR 323",
+              "required": true
+            },
+            {
+              "course": "ENGR 324",
+              "required": true
+            },
+            {
+              "course": "ENGR 325",
+              "required": true
+            }
+          ],
+          "notes": "ENGR 102 is 1 credit; ENGR 321 is 2 credits; ENGR 324L (1 cr) included. Total 16 credits."
+        },
+        {
+          "name": "Engineering Systems",
+          "description": "All required",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "ENGR 311",
+              "required": true
+            },
+            {
+              "course": "ENGR 312",
+              "required": true
+            },
+            {
+              "course": "ENGR 313",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Environmental Engineering Specialization",
+          "description": "All required",
+          "slots": 6,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "ENGR 361",
+              "required": true
+            },
+            {
+              "course": "ENGR 361L",
+              "required": true
+            },
+            {
+              "course": "ENGR 362",
+              "required": true
+            },
+            {
+              "course": "ENGR 363",
+              "required": true
+            },
+            {
+              "course": "ENGR 383",
+              "required": true
+            },
+            {
+              "course": "ENGR 393",
+              "required": true
+            }
+          ],
+          "notes": "ENGR 361L is 1 credit; ENGR 383 and ENGR 393 are 4 credits each. Total 18 credits."
+        },
+        {
+          "name": "Math & Science",
+          "description": "All required",
+          "slots": 10,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "BIOL 101",
+              "required": true
+            },
+            {
+              "course": "BIOL 111",
+              "required": true
+            },
+            {
+              "course": "CHEM 171",
+              "required": true
+            },
+            {
+              "course": "CHEM 173",
+              "required": true
+            },
+            {
+              "course": "COMP 170",
+              "required": true
+            },
+            {
+              "course": "MATH 161",
+              "required": true
+            },
+            {
+              "course": "MATH 162",
+              "required": true
+            },
+            {
+              "course": "MATH 263",
+              "required": true
+            },
+            {
+              "course": "MATH 266",
+              "required": true
+            },
+            {
+              "course": "STAT 203",
+              "required": true
+            }
+          ],
+          "notes": "Total ~29 credits (variable credit courses). Also requires PHYS 121, PHYS 122, PHYS 112L."
+        },
+        {
+          "name": "Physics",
+          "description": "All required",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "PHYS 121",
+              "required": true
+            },
+            {
+              "course": "PHYS 122",
+              "required": true
+            }
+          ],
+          "notes": "PHYS 112L (1 cr) is also required. Total 7 credits."
+        }
+      ]
+    },
+    {
+      "code": "ECON-BA",
+      "name": "Economics (BA)",
+      "type": "major",
+      "department": "ECON",
+      "total_credits": 36,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "core_waivers": [],
+      "notes": [
+        "Only one ECON 399 Special Topics course may count toward the major.",
+        "Students pursuing doctoral study should take MATH 161, MATH 162, MATH 263, MATH 212, STAT 304, and STAT 305.",
+        "CAS requires two Writing Intensive courses and foreign language at 102-level or higher."
+      ],
+      "categories": [
+        {
+          "name": "Mathematics Requirement",
+          "description": "Select one calculus course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "MATH 130",
+            "MATH 131",
+            "MATH 161"
+          ]
+        },
+        {
+          "name": "Statistics Requirement",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "STAT 103",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Core Economics Courses",
+          "description": "All four required",
+          "slots": 4,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "ECON 201",
+              "required": true
+            },
+            {
+              "course": "ECON 202",
+              "required": true
+            },
+            {
+              "course": "ECON 303",
+              "required": true
+            },
+            {
+              "course": "ECON 304",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Economics Electives",
+          "description": "Select six 300-level economics courses",
+          "slots": 6,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ECON 320",
+            "ECON 323",
+            "ECON 324",
+            "ECON 325",
+            "ECON 327",
+            "ECON 328",
+            "ECON 329",
+            "ECON 334",
+            "ECON 336",
+            "ECON 346",
+            "ECON 360",
+            "ECON 370",
+            "ECON 399",
+            "MATH 360"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "CJC-BS",
+      "name": "Criminal Justice & Criminology (BS)",
+      "type": "major",
+      "department": "CJC",
+      "total_credits": 36,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "core_waivers": [],
+      "notes": [
+        "Students should complete CJC 101 first before declaring the major.",
+        "Double majors in Sociology/CJC or Psychology/CJC may fulfill research methods in their other discipline.",
+        "Elective option: 6 CJC electives + external statistics course (SOCL 301, PSYC 304, or STAT 103), OR 5 CJC electives + CJC 206.",
+        "CAS requires two Writing Intensive courses and foreign language at 102-level or higher."
+      ],
+      "categories": [
+        {
+          "name": "Required Courses",
+          "description": "All three required",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "CJC 101",
+              "required": true
+            },
+            {
+              "course": "CJC 201",
+              "required": true
+            },
+            {
+              "course": "CJC 205",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "System Components",
+          "description": "Select two of the following",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "CJC 202",
+            "CJC 203",
+            "CJC 204",
+            "CJC 323"
+          ]
+        },
+        {
+          "name": "Statistics",
+          "description": "Select one statistics course (CJC 206 or external)",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "CJC 206",
+            "SOCL 301",
+            "PSYC 304",
+            "STAT 103"
+          ]
+        },
+        {
+          "name": "CJC Electives",
+          "description": "Select five or six CJC electives (five if taking CJC 206, six if using external statistics)",
+          "slots": 5,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "CJC 202",
+            "CJC 203",
+            "CJC 204",
+            "CJC 206",
+            "CJC 302",
+            "CJC 310",
+            "CJC 312",
+            "CJC 322",
+            "CJC 323",
+            "CJC 336",
+            "CJC 337",
+            "CJC 338",
+            "CJC 345",
+            "CJC 346",
+            "CJC 351",
+            "CJC 352",
+            "CJC 353",
+            "CJC 354",
+            "CJC 360",
+            "CJC 365",
+            "CJC 366",
+            "CJC 370",
+            "CJC 371",
+            "CJC 372",
+            "CJC 373",
+            "CJC 374",
+            "CJC 375",
+            "CJC 376",
+            "CJC 377",
+            "CJC 378",
+            "CJC 379",
+            "CJC 380",
+            "CJC 395",
+            "CJC 396"
+          ],
+          "notes": "System Components courses not used for that requirement may count here. If using external statistics, one additional elective is needed (6 total)."
+        },
+        {
+          "name": "Capstone",
+          "description": "Select one capstone option",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "CJC 399",
+            "CJC 390",
+            "CJC 391"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "PSYC-BS",
+      "name": "Psychology (BS)",
+      "type": "major",
+      "department": "PSYC",
+      "total_credits": 47,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "core_waivers": [
+        "Societal/Cultural",
+        "Quantitative"
+      ],
+      "notes": [
+        "PSYC 304 is prerequisite for PSYC 306; cannot take both simultaneously.",
+        "No alternative statistics course fulfills PSYC 306 prerequisite for majors.",
+        "Honors track requires 3.5 cumulative GPA and includes PSYC 369 + PSYC 370.",
+        "Maximum three courses from one department may count toward two majors (exceptions for Neuroscience and Social Work co-majors).",
+        "Maximum three major courses may transfer from other institutions.",
+        "PSYC 397 and PSYC 370 count toward engaged learning; PSYC 399 does not.",
+        "Two ancillary quantitative courses required (not counted in 47 major credits)."
+      ],
+      "categories": [
+        {
+          "name": "Foundation Courses",
+          "description": "All required",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "PSYC 101",
+              "required": true
+            },
+            {
+              "course": "PSYC 304",
+              "required": true
+            },
+            {
+              "course": "PSYC 306",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Advising Seminar",
+          "description": "Required 1-credit seminar",
+          "slots": 1,
+          "credits_per_slot": 1,
+          "eligible_courses_fixed": [
+            {
+              "course": "PSYC 201",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Diversity and Inclusion",
+          "description": "Select one course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "PSYC 235",
+            "PSYC 237",
+            "PSYC 238",
+            "PSYC 239",
+            "PSYC 360",
+            "PSYC 374"
+          ]
+        },
+        {
+          "name": "Biological Pillar",
+          "description": "Select one course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "PSYC 240",
+            "NEUR 101"
+          ]
+        },
+        {
+          "name": "Cognitive Pillar",
+          "description": "Select one course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "PSYC 250",
+            "PSYC 251",
+            "PSYC 307",
+            "PSYC 382"
+          ]
+        },
+        {
+          "name": "Developmental Pillar",
+          "description": "Select one course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "PSYC 273",
+            "PSYC 274"
+          ]
+        },
+        {
+          "name": "Mental Health Pillar",
+          "description": "Select one course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "PSYC 331",
+            "PSYC 346"
+          ]
+        },
+        {
+          "name": "Social Pillar",
+          "description": "Required course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "PSYC 275",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Advanced Lab",
+          "description": "Select one lab course",
+          "slots": 1,
+          "credits_per_slot": 1,
+          "eligible_courses": [
+            "PSYC 311",
+            "PSYC 312",
+            "PSYC 313",
+            "PSYC 314",
+            "PSYC 315",
+            "PSYC 316",
+            "PSYC 318",
+            "PSYC 321",
+            "PSYC 327"
+          ]
+        },
+        {
+          "name": "Capstone or Second Lab",
+          "description": "Select capstone (PSYC 370, 2 credits) or a second advanced lab (1 credit)",
+          "slots": 1,
+          "credits_per_slot": 2,
+          "eligible_courses": [
+            "PSYC 370",
+            "PSYC 311",
+            "PSYC 312",
+            "PSYC 313",
+            "PSYC 314",
+            "PSYC 315",
+            "PSYC 316",
+            "PSYC 318",
+            "PSYC 321",
+            "PSYC 327"
+          ],
+          "notes": "PSYC 370 is 2 credits; second lab option is 1 credit. Honors students take PSYC 369 + PSYC 370 instead."
+        },
+        {
+          "name": "Psychology Electives",
+          "description": "Select two psychology electives",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "PSYC 235",
+            "PSYC 274",
+            "PSYC 276",
+            "PSYC 280",
+            "PSYC 332",
+            "PSYC 340",
+            "PSYC 348",
+            "PSYC 350",
+            "PSYC 352",
+            "PSYC 355",
+            "PSYC 362",
+            "PSYC 368",
+            "PSYC 371",
+            "PSYC 372",
+            "PSYC 373",
+            "PSYC 375",
+            "PSYC 376",
+            "PSYC 377",
+            "PSYC 378",
+            "PSYC 383",
+            "PSYC 384",
+            "PSYC 386",
+            "PSYC 387",
+            "PSYC 397",
+            "PSYC 399",
+            "NEUR 101"
+          ]
+        },
+        {
+          "name": "Ancillary Quantitative Courses",
+          "description": "Select two quantitative courses from outside psychology",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "COMP 125",
+            "COMP 150",
+            "COMP 170",
+            "COMP 180",
+            "DSCI 101",
+            "MATH 108",
+            "MATH 117",
+            "MATH 118",
+            "MATH 131",
+            "MATH 132",
+            "MATH 161",
+            "MATH 162",
+            "MATH 215",
+            "STAT 103"
+          ],
+          "notes": "These do not count toward the 47 major credits but are required for the degree."
+        }
+      ]
+    },
+    {
+      "code": "SOCL-BA",
+      "name": "Sociology (BA)",
+      "type": "major",
+      "department": "SOCL",
+      "total_credits": 34,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "core_waivers": [
+        "Societal/Cultural"
+      ],
+      "notes": [
+        "Any SOCL 100-level course is prerequisite for SOCL 205 (except by special permission).",
+        "SOCL 205, 206, and 301 are prerequisites for SOCL 365.",
+        "Not more than 5 courses or 15 semester hours accepted in transfer.",
+        "One course from another social science may substitute for a SOCL elective with departmental permission.",
+        "Only one semester of SOCL 380 (Internship) may count toward the major.",
+        "Five of six electives must be from SOCL 210-380 range."
+      ],
+      "categories": [
+        {
+          "name": "Required Courses",
+          "description": "All five required",
+          "slots": 5,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "SOCL 101",
+              "required": true
+            },
+            {
+              "course": "SOCL 205",
+              "required": true
+            },
+            {
+              "course": "SOCL 206",
+              "required": true
+            },
+            {
+              "course": "SOCL 301",
+              "required": true
+            },
+            {
+              "course": "SOCL 365",
+              "required": true
+            }
+          ],
+          "notes": "SOCL 301 is 4 credits; others are 3 credits each."
+        },
+        {
+          "name": "Upper-Level Electives",
+          "description": "Select five electives from SOCL 210-380",
+          "slots": 5,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "SOCL 210",
+            "SOCL 215",
+            "SOCL 216",
+            "SOCL 220",
+            "SOCL 221",
+            "SOCL 222",
+            "SOCL 225",
+            "SOCL 228",
+            "SOCL 230",
+            "SOCL 231",
+            "SOCL 234",
+            "SOCL 235",
+            "SOCL 236",
+            "SOCL 240",
+            "SOCL 250",
+            "SOCL 252",
+            "SOCL 255",
+            "SOCL 260",
+            "SOCL 261",
+            "SOCL 265",
+            "SOCL 272",
+            "SOCL 280",
+            "SOCL 302",
+            "SOCL 304",
+            "SOCL 306",
+            "SOCL 335",
+            "SOCL 370",
+            "SOCL 380"
+          ]
+        },
+        {
+          "name": "General Elective",
+          "description": "One additional SOCL elective from any level",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "SOCL 121",
+            "SOCL 122",
+            "SOCL 125",
+            "SOCL 145",
+            "SOCL 171",
+            "SOCL 210",
+            "SOCL 215",
+            "SOCL 216",
+            "SOCL 220",
+            "SOCL 221",
+            "SOCL 222",
+            "SOCL 225",
+            "SOCL 228",
+            "SOCL 230",
+            "SOCL 231",
+            "SOCL 234",
+            "SOCL 235",
+            "SOCL 236",
+            "SOCL 240",
+            "SOCL 250",
+            "SOCL 252",
+            "SOCL 255",
+            "SOCL 260",
+            "SOCL 261",
+            "SOCL 265",
+            "SOCL 272",
+            "SOCL 280",
+            "SOCL 302",
+            "SOCL 304",
+            "SOCL 306",
+            "SOCL 335",
+            "SOCL 370",
+            "SOCL 380"
+          ],
+          "notes": "May also be a course from another social science with departmental permission."
+        }
+      ]
+    },
+    {
+      "code": "SOCL-BA-ANTH",
+      "name": "Sociology-Anthropology (BA)",
+      "type": "major",
+      "department": "SOCL",
+      "total_credits": 36,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "core_waivers": [
+        "Societal/Cultural"
+      ],
+      "notes": [
+        "This is an interdisciplinary major combining Sociology and Anthropology.",
+        "CAS requires two Writing Intensive courses and foreign language at 102-level or higher."
+      ],
+      "categories": [
+        {
+          "name": "Natural Science Intro",
+          "description": "Select one anthropology natural science course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ANTH 101",
+            "ANTH 103",
+            "ANTH 104",
+            "ANTH 105",
+            "ANTH 106",
+            "ANTH 245"
+          ]
+        },
+        {
+          "name": "Social Science Intro Courses",
+          "description": "One ANTH social science intro + SOCL 101",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "SOCL 101",
+            "ANTH 100",
+            "ANTH 102"
+          ],
+          "notes": "SOCL 101 is required; select one of ANTH 100 or ANTH 102. Required: SOCL 101; remaining are electives"
+        },
+        {
+          "name": "Ethnographic Area Course",
+          "description": "Select one ANTH ethnographic area course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ANTH 207",
+            "ANTH 208",
+            "ANTH 211",
+            "ANTH 212",
+            "ANTH 213",
+            "ANTH 214",
+            "ANTH 215",
+            "ANTH 216",
+            "ANTH 217",
+            "ANTH 220",
+            "ANTH 222",
+            "ANTH 224",
+            "ANTH 225"
+          ]
+        },
+        {
+          "name": "Theory Course",
+          "description": "Select one theory course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "SOCL 205",
+            "ANTH 304"
+          ]
+        },
+        {
+          "name": "Methods Courses",
+          "description": "SOCL 206 required + one additional methods course",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "SOCL 206",
+            "ANTH 356",
+            "ANTH 365",
+            "SOCL 301"
+          ],
+          "notes": "SOCL 206 is required; select one of ANTH 356, ANTH 365, or SOCL 301. Required: SOCL 206; remaining are electives"
+        },
+        {
+          "name": "Anthropology Electives",
+          "description": "Select two anthropology elective courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ANTH 241",
+            "ANTH 242",
+            "ANTH 243",
+            "ANTH 246",
+            "ANTH 247",
+            "ANTH 280",
+            "ANTH 281",
+            "ANTH 324",
+            "ANTH 325",
+            "ANTH 326",
+            "ANTH 327",
+            "ANTH 359",
+            "ANTH 360",
+            "ANTH 362"
+          ],
+          "notes": "Any additional 200-300 level ANTH course also eligible."
+        },
+        {
+          "name": "Sociology Electives",
+          "description": "Select two sociology elective courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "SOCL 121",
+            "SOCL 122",
+            "SOCL 123",
+            "SOCL 125",
+            "SOCL 145",
+            "SOCL 171",
+            "SOCL 210",
+            "SOCL 215",
+            "SOCL 216",
+            "SOCL 220",
+            "SOCL 221",
+            "SOCL 222",
+            "SOCL 225",
+            "SOCL 228",
+            "SOCL 230",
+            "SOCL 231",
+            "SOCL 234",
+            "SOCL 235",
+            "SOCL 236",
+            "SOCL 240",
+            "SOCL 250",
+            "SOCL 252",
+            "SOCL 255",
+            "SOCL 260",
+            "SOCL 261",
+            "SOCL 265",
+            "SOCL 272",
+            "SOCL 280",
+            "SOCL 302",
+            "SOCL 304",
+            "SOCL 306",
+            "SOCL 335",
+            "SOCL 370",
+            "SOCL 380"
+          ],
+          "notes": "Any 200-300 level SOCL course also eligible."
+        },
+        {
+          "name": "Theory/Methods Seminar",
+          "description": "Select one capstone seminar",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ANTH 317",
+            "SOCL 365"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "HMSR-BS",
+      "name": "Human Services (BS)",
+      "type": "major",
+      "department": "HMSV",
+      "total_credits": 45,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "core_waivers": [],
+      "notes": [
+        "Students must minor in one of five constituent departments: Criminal Justice, Political Science, Psychology, Sociology, or Social Work.",
+        "At least one course required from each of the five constituent departments.",
+        "Maximum six courses may count for both majors if double-majoring in Human Services and one constituent field.",
+        "Two service-learning courses required (may come from basic, concentration, elective, or outside major).",
+        "CAS requires two Writing Intensive courses and foreign language at 102-level or higher."
+      ],
+      "categories": [
+        {
+          "name": "Basic Required Courses",
+          "description": "Three required courses",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "PSYC 101",
+              "required": true
+            },
+            {
+              "course": "HMSV 101",
+              "required": true
+            },
+            {
+              "course": "HMSV 201",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Statistics",
+          "description": "Select one statistics course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "CJC 206",
+            "PSYC 304",
+            "SOCL 301"
+          ]
+        },
+        {
+          "name": "Research Methods",
+          "description": "Select one research methods course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "CJC 205",
+            "PSYC 306",
+            "SOCL 206",
+            "SOWK 390"
+          ]
+        },
+        {
+          "name": "Urban Politics",
+          "description": "Select one urban politics course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "PLSC 333",
+            "PLSC 334",
+            "PLSC 390",
+            "PLSC 391"
+          ]
+        },
+        {
+          "name": "Clinical Competency",
+          "description": "Select one clinical course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "PSYC 368",
+            "SOWK 303"
+          ]
+        },
+        {
+          "name": "Supervised Fieldwork I",
+          "description": "Select one fieldwork course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "CJC 390",
+            "PLSC 370",
+            "PSYC 390",
+            "SOCL 380"
+          ]
+        },
+        {
+          "name": "Supervised Fieldwork II",
+          "description": "Required capstone fieldwork",
+          "slots": 1,
+          "credits_per_slot": 6,
+          "eligible_courses_fixed": [
+            {
+              "course": "HMSV 390",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Concentration: Child, Adolescent & Family Services",
+          "description": "Select three courses from this concentration (if chosen)",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "CJC 302",
+            "CJC 395",
+            "PSYC 238",
+            "PSYC 273",
+            "PSYC 348",
+            "SOCL 231",
+            "SOCL 240",
+            "SOWK 205"
+          ],
+          "notes": "Choose ONE concentration area. This is one of three options."
+        },
+        {
+          "name": "Concentration: Mental Health",
+          "description": "Select three courses from this concentration (if chosen)",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "CJC 372",
+            "CJC 395",
+            "PSYC 235",
+            "PSYC 331",
+            "PSYC 346",
+            "PSYC 373",
+            "SOWK 361"
+          ],
+          "notes": "Choose ONE concentration area. This is one of three options."
+        },
+        {
+          "name": "Concentration: Gerontology and Aging",
+          "description": "Select three courses from this concentration (if chosen)",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "SOCL 221",
+            "SOCL 236"
+          ],
+          "notes": "Choose ONE concentration area. This is one of three options. Additional courses may be available — catalog listing was limited."
+        },
+        {
+          "name": "Social Solutions and Social Change Elective",
+          "description": "Select one course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "CJC 372",
+            "PSYC 275",
+            "PSYC 374",
+            "SOCL 221",
+            "SOCL 255",
+            "SOCL 261",
+            "SOWK 305"
+          ]
+        },
+        {
+          "name": "Human Diversity Elective",
+          "description": "Select one course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "ANTH 100",
+            "ANTH 102",
+            "PLSC 218",
+            "PLSC 319",
+            "PLSC 323",
+            "PSYC 235",
+            "PSYC 340",
+            "PSYC 386",
+            "SOCL 122",
+            "SOCL 171",
+            "SOCL 250",
+            "SOCL 252",
+            "SOCL 272",
+            "SOWK 361",
+            "SOWK 370"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "FNAR-BA-VC",
+      "name": "Visual Communication (BA)",
+      "type": "major",
+      "department": "FNAR",
+      "total_credits": 45,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "Visual Communication III (FNAR 332) is offered Fall only; Visual Communication IV (FNAR 382) is offered Spring only.",
+        "Five optional electives listed but not required: FNAR 118, FNAR 213, COMM 275, COMM 299, FNAR 381."
+      ],
+      "categories": [
+        {
+          "name": "Foundation Courses",
+          "description": "Required introductory studio courses",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "FNAR 113",
+              "required": true
+            },
+            {
+              "course": "FNAR 112",
+              "required": true
+            },
+            {
+              "course": "FNAR 190",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Art History",
+          "description": "Select one art history course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "FNAR 202",
+            "FNAR 364"
+          ]
+        },
+        {
+          "name": "Applied Courses",
+          "description": "Required visual communication studio sequence plus photography and digital media",
+          "slots": 9,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "FNAR 115",
+              "required": true
+            },
+            {
+              "course": "FNAR 132",
+              "required": true
+            },
+            {
+              "course": "FNAR 232",
+              "required": true
+            },
+            {
+              "course": "FNAR 233",
+              "required": true
+            },
+            {
+              "course": "FNAR 332",
+              "required": true
+            },
+            {
+              "course": "FNAR 333",
+              "required": true
+            },
+            {
+              "course": "FNAR 334",
+              "required": true
+            },
+            {
+              "course": "FNAR 382",
+              "required": true
+            },
+            {
+              "course": "FNAR 383",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Synthesis Courses",
+          "description": "Internship and capstone",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "FNAR 380",
+              "required": true
+            },
+            {
+              "course": "FNAR 398",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "code": "MUSC-BA",
+      "name": "Music (BA)",
+      "type": "major",
+      "department": "MUSC",
+      "total_credits": 42,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "MUSC 144 and MUSC 145 must be taken concurrently; MUSC 244 and MUSC 245 must be taken concurrently.",
+        "AP Music Theory score 3-4 gives credit for MUSC 144; score 5 gives credit for MUSC 144 and MUSC 244.",
+        "Applied lessons preferably on the same instrument; multiple instruments approved case-by-case.",
+        "Faculty expectation is MUSC 387 for capstone unless Director approval for MUSC 388.",
+        "MUSC 101, 102, 103, 142 excluded from General Music Choice; 1-credit ensemble/applied courses may count."
+      ],
+      "categories": [
+        {
+          "name": "Music Theory and Musicianship",
+          "description": "Required theory and musicianship sequence",
+          "slots": 5,
+          "credits_per_slot": null,
+          "eligible_courses_fixed": [
+            {
+              "course": "MUSC 144",
+              "required": true,
+              "credits": 3
+            },
+            {
+              "course": "MUSC 145",
+              "required": true,
+              "credits": 1
+            },
+            {
+              "course": "MUSC 244",
+              "required": true,
+              "credits": 3
+            },
+            {
+              "course": "MUSC 245",
+              "required": true,
+              "credits": 1
+            },
+            {
+              "course": "MUSC 344",
+              "required": true,
+              "credits": 3
+            }
+          ],
+          "notes": "Catalog lists 10 credits for this category. 144+145 concurrent; 244+245 concurrent."
+        },
+        {
+          "name": "Music History",
+          "description": "MUSC 353 required; select one additional history course",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "MUSC 353",
+            "MUSC 252",
+            "MUSC 256",
+            "MUSC 354"
+          ],
+          "notes": "MUSC 353 required; select one of MUSC 252, 256, or 354. Required: MUSC 353; remaining are electives"
+        },
+        {
+          "name": "Applied Music Lessons",
+          "description": "Six credits of applied lessons on instrument(s)",
+          "slots": 6,
+          "credits_per_slot": 1,
+          "eligible_courses": [
+            "MUSC 280A",
+            "MUSC 280AA",
+            "MUSC 280B",
+            "MUSC 280BB",
+            "MUSC 280C",
+            "MUSC 280E",
+            "MUSC 280F",
+            "MUSC 280G",
+            "MUSC 280I",
+            "MUSC 280J",
+            "MUSC 280K",
+            "MUSC 280L",
+            "MUSC 280M",
+            "MUSC 280N",
+            "MUSC 280O",
+            "MUSC 280P",
+            "MUSC 280Q",
+            "MUSC 280R",
+            "MUSC 280S",
+            "MUSC 280U",
+            "MUSC 280V",
+            "MUSC 280Y",
+            "MUSC 280Z",
+            "MUSC 380A",
+            "MUSC 380AA",
+            "MUSC 380B",
+            "MUSC 380BB",
+            "MUSC 380C",
+            "MUSC 380E",
+            "MUSC 380F",
+            "MUSC 380G",
+            "MUSC 380I",
+            "MUSC 380J",
+            "MUSC 380K",
+            "MUSC 380L",
+            "MUSC 380M",
+            "MUSC 380N",
+            "MUSC 380O",
+            "MUSC 380P",
+            "MUSC 380Q",
+            "MUSC 380R",
+            "MUSC 380S",
+            "MUSC 380U",
+            "MUSC 380V",
+            "MUSC 380Y",
+            "MUSC 380Z"
+          ],
+          "notes": "Each applied lesson is 1 credit. Preferably same instrument for all 6 credits."
+        },
+        {
+          "name": "Ensembles",
+          "description": "Six credits of ensemble participation",
+          "slots": 6,
+          "credits_per_slot": 1,
+          "eligible_courses": [
+            "MUSC 105",
+            "MUSC 107",
+            "MUSC 108",
+            "MUSC 109",
+            "MUSC 110",
+            "MUSC 111",
+            "MUSC 207",
+            "MUSC 289",
+            "MUSC 290"
+          ],
+          "notes": "Each ensemble is 1 credit. Select any combination totaling 6 credits."
+        },
+        {
+          "name": "Senior Capstone Experience",
+          "description": "Solo recital or lecture-recital",
+          "slots": 1,
+          "credits_per_slot": 1,
+          "eligible_courses": [
+            "MUSC 387",
+            "MUSC 388"
+          ],
+          "notes": "Faculty expectation is MUSC 387 unless Director approval."
+        },
+        {
+          "name": "General Music Choice",
+          "description": "Twelve credits of music electives",
+          "slots": 4,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "MUSC 122",
+            "MUSC 185",
+            "MUSC 201",
+            "MUSC 246",
+            "MUSC 247",
+            "MUSC 248",
+            "MUSC 252",
+            "MUSC 255",
+            "MUSC 256",
+            "MUSC 260",
+            "MUSC 345",
+            "MUSC 354",
+            "MUSC 363",
+            "MUSC 364",
+            "MUSC 365",
+            "MUSC 370",
+            "MUSC 374",
+            "MUSC 385",
+            "MUSC 389",
+            "MUSC 394"
+          ],
+          "notes": "MUSC 101, 102, 103, 142 excluded. 1-credit ensemble/applied courses may also count."
+        }
+      ]
+    },
+    {
+      "code": "MUSC-BA-JAZZ",
+      "name": "Music: Jazz Studies (BA)",
+      "type": "major",
+      "department": "MUSC",
+      "total_credits": 39,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "MUSC 144 and MUSC 145 must be taken concurrently; MUSC 244 and MUSC 245 must be taken concurrently.",
+        "AP Music Theory score 3-4 gives credit for MUSC 144; score 5 gives credit for MUSC 144 and MUSC 244.",
+        "Applied lessons preferably on the same instrument; multiple instruments approved case-by-case.",
+        "Jazz Ensemble (MUSC 109) is 1 credit; 6 semesters required. MUSC 290 Jazz Combo may substitute with director approval.",
+        "Capstone is MUSC 387 Solo Recital."
+      ],
+      "categories": [
+        {
+          "name": "Music Theory and Musicianship",
+          "description": "Required theory and musicianship sequence",
+          "slots": 5,
+          "credits_per_slot": null,
+          "eligible_courses_fixed": [
+            {
+              "course": "MUSC 144",
+              "required": true,
+              "credits": 3
+            },
+            {
+              "course": "MUSC 145",
+              "required": true,
+              "credits": 1
+            },
+            {
+              "course": "MUSC 244",
+              "required": true,
+              "credits": 3
+            },
+            {
+              "course": "MUSC 245",
+              "required": true,
+              "credits": 1
+            },
+            {
+              "course": "MUSC 344",
+              "required": true,
+              "credits": 3
+            }
+          ],
+          "notes": "144+145 concurrent; 244+245 concurrent."
+        },
+        {
+          "name": "Music History",
+          "description": "Required jazz and general music history",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "MUSC 256",
+              "required": true
+            },
+            {
+              "course": "MUSC 353",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Applied Music Lessons",
+          "description": "Six credits of applied lessons on instrument(s)",
+          "slots": 6,
+          "credits_per_slot": 1,
+          "eligible_courses": [
+            "MUSC 280A",
+            "MUSC 280AA",
+            "MUSC 280B",
+            "MUSC 280BB",
+            "MUSC 280C",
+            "MUSC 280E",
+            "MUSC 280F",
+            "MUSC 280G",
+            "MUSC 280I",
+            "MUSC 280J",
+            "MUSC 280K",
+            "MUSC 280L",
+            "MUSC 280M",
+            "MUSC 280N",
+            "MUSC 280O",
+            "MUSC 280P",
+            "MUSC 280Q",
+            "MUSC 280R",
+            "MUSC 280S",
+            "MUSC 280U",
+            "MUSC 280V",
+            "MUSC 280Y",
+            "MUSC 280Z",
+            "MUSC 380A",
+            "MUSC 380AA",
+            "MUSC 380B",
+            "MUSC 380BB",
+            "MUSC 380C",
+            "MUSC 380E",
+            "MUSC 380F",
+            "MUSC 380G",
+            "MUSC 380I",
+            "MUSC 380J",
+            "MUSC 380K",
+            "MUSC 380L",
+            "MUSC 380M",
+            "MUSC 380N",
+            "MUSC 380O",
+            "MUSC 380P",
+            "MUSC 380Q",
+            "MUSC 380R",
+            "MUSC 380S",
+            "MUSC 380U",
+            "MUSC 380V",
+            "MUSC 380Y",
+            "MUSC 380Z"
+          ],
+          "notes": "Each applied lesson is 1 credit. Preferably same instrument."
+        },
+        {
+          "name": "Jazz Ensemble",
+          "description": "Six semesters of jazz ensemble",
+          "slots": 6,
+          "credits_per_slot": 1,
+          "eligible_courses": [
+            "MUSC 109",
+            "MUSC 290"
+          ],
+          "notes": "MUSC 109 required; MUSC 290 Jazz Combo may substitute with director approval."
+        },
+        {
+          "name": "Required Jazz Studies Courses",
+          "description": "Core jazz curriculum",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "MUSC 185",
+              "required": true
+            },
+            {
+              "course": "MUSC 248",
+              "required": true
+            },
+            {
+              "course": "MUSC 385",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Senior Capstone Experience",
+          "description": "Solo recital",
+          "slots": 1,
+          "credits_per_slot": 1,
+          "eligible_courses_fixed": [
+            {
+              "course": "MUSC 387",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Music Elective",
+          "description": "Three credits of additional music coursework",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "MUSC 122",
+            "MUSC 201",
+            "MUSC 246",
+            "MUSC 247",
+            "MUSC 252",
+            "MUSC 255",
+            "MUSC 260",
+            "MUSC 345",
+            "MUSC 354",
+            "MUSC 363",
+            "MUSC 364",
+            "MUSC 365",
+            "MUSC 370",
+            "MUSC 374",
+            "MUSC 389",
+            "MUSC 394"
+          ],
+          "notes": "May also use additional 1-credit applied lessons or ensemble courses to reach 3 credits."
+        }
+      ]
+    },
+    {
+      "code": "MUSC-BA-LITM",
+      "name": "Music: Liturgical Music (BA)",
+      "type": "major",
+      "department": "MUSC",
+      "total_credits": 42,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "MUSC 144 and MUSC 145 must be taken concurrently; MUSC 244 and MUSC 245 must be taken concurrently.",
+        "AP Music Theory score 3-4 gives credit for MUSC 144; score 5 gives credit for MUSC 144 and MUSC 244.",
+        "Applied lessons preferably on the same instrument; multiple instruments approved case-by-case.",
+        "Requires 3 credits of MUSC 108 Liturgical Choir: Cantorum plus 3 credits from Chorus or Chamber Choir.",
+        "Includes required 3-credit internship (MUSC 394)."
+      ],
+      "categories": [
+        {
+          "name": "Music Theory and Musicianship",
+          "description": "Required theory and musicianship sequence",
+          "slots": 5,
+          "credits_per_slot": null,
+          "eligible_courses_fixed": [
+            {
+              "course": "MUSC 144",
+              "required": true,
+              "credits": 3
+            },
+            {
+              "course": "MUSC 145",
+              "required": true,
+              "credits": 1
+            },
+            {
+              "course": "MUSC 244",
+              "required": true,
+              "credits": 3
+            },
+            {
+              "course": "MUSC 245",
+              "required": true,
+              "credits": 1
+            },
+            {
+              "course": "MUSC 344",
+              "required": true,
+              "credits": 3
+            }
+          ],
+          "notes": "144+145 concurrent; 244+245 concurrent."
+        },
+        {
+          "name": "Music History",
+          "description": "Required music history sequence",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "MUSC 252",
+              "required": true
+            },
+            {
+              "course": "MUSC 353",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Applied Music Lessons",
+          "description": "Six credits of applied lessons on instrument(s)",
+          "slots": 6,
+          "credits_per_slot": 1,
+          "eligible_courses": [
+            "MUSC 280A",
+            "MUSC 280AA",
+            "MUSC 280B",
+            "MUSC 280BB",
+            "MUSC 280C",
+            "MUSC 280E",
+            "MUSC 280F",
+            "MUSC 280G",
+            "MUSC 280I",
+            "MUSC 280J",
+            "MUSC 280K",
+            "MUSC 280L",
+            "MUSC 280M",
+            "MUSC 280N",
+            "MUSC 280O",
+            "MUSC 280P",
+            "MUSC 280Q",
+            "MUSC 280R",
+            "MUSC 280S",
+            "MUSC 280U",
+            "MUSC 280V",
+            "MUSC 280Y",
+            "MUSC 280Z",
+            "MUSC 380A",
+            "MUSC 380AA",
+            "MUSC 380B",
+            "MUSC 380BB",
+            "MUSC 380C",
+            "MUSC 380E",
+            "MUSC 380F",
+            "MUSC 380G",
+            "MUSC 380I",
+            "MUSC 380J",
+            "MUSC 380K",
+            "MUSC 380L",
+            "MUSC 380M",
+            "MUSC 380N",
+            "MUSC 380O",
+            "MUSC 380P",
+            "MUSC 380Q",
+            "MUSC 380R",
+            "MUSC 380S",
+            "MUSC 380U",
+            "MUSC 380V",
+            "MUSC 380Y",
+            "MUSC 380Z"
+          ],
+          "notes": "Each applied lesson is 1 credit. Preferably same instrument."
+        },
+        {
+          "name": "Ensembles",
+          "description": "Three credits Liturgical Choir plus three credits Chorus or Chamber Choir",
+          "slots": 6,
+          "credits_per_slot": 1,
+          "eligible_courses": [
+            "MUSC 108",
+            "MUSC 107",
+            "MUSC 207"
+          ],
+          "notes": "3 credits of MUSC 108 (Liturgical Choir: Cantorum) required; remaining 3 from MUSC 107 or MUSC 207."
+        },
+        {
+          "name": "Liturgical Music Requirements",
+          "description": "Required liturgical music courses",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "MUSC 255",
+              "required": true
+            },
+            {
+              "course": "MUSC 333",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Internship",
+          "description": "Required music internship",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "MUSC 394",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Music Elective",
+          "description": "Select one additional music course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "MUSC 260",
+            "MUSC 185",
+            "MUSC 246",
+            "MUSC 280I"
+          ],
+          "notes": "MUSC 280I (Organ) eligible only if not the student's primary applied instrument."
+        },
+        {
+          "name": "Senior Capstone Experience",
+          "description": "Solo recital or lecture-recital",
+          "slots": 1,
+          "credits_per_slot": 1,
+          "eligible_courses": [
+            "MUSC 387",
+            "MUSC 388"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "MUSC-BA-VOCP",
+      "name": "Music: Vocal Performance (BA)",
+      "type": "major",
+      "department": "MUSC",
+      "total_credits": 42,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "MUSC 144 and MUSC 145 must be taken concurrently; MUSC 244 and MUSC 245 must be taken concurrently.",
+        "AP Music Theory score 3-4 gives credit for MUSC 144; score 5 gives credit for MUSC 144 and MUSC 244.",
+        "Applied lessons primarily on voice (MUSC 280K/380K); other instruments case-by-case.",
+        "All Vocal Performance students are required to give a full recital in their senior year.",
+        "Ensembles must be from MUSC 107 (Chorus) or MUSC 207 (Chamber Choir)."
+      ],
+      "categories": [
+        {
+          "name": "Music Theory and Musicianship",
+          "description": "Required theory and musicianship sequence",
+          "slots": 5,
+          "credits_per_slot": null,
+          "eligible_courses_fixed": [
+            {
+              "course": "MUSC 144",
+              "required": true,
+              "credits": 3
+            },
+            {
+              "course": "MUSC 145",
+              "required": true,
+              "credits": 1
+            },
+            {
+              "course": "MUSC 244",
+              "required": true,
+              "credits": 3
+            },
+            {
+              "course": "MUSC 245",
+              "required": true,
+              "credits": 1
+            },
+            {
+              "course": "MUSC 344",
+              "required": true,
+              "credits": 3
+            }
+          ],
+          "notes": "144+145 concurrent; 244+245 concurrent."
+        },
+        {
+          "name": "Music History",
+          "description": "MUSC 353 required; select one additional history course",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "MUSC 353",
+            "MUSC 252",
+            "MUSC 256",
+            "MUSC 354"
+          ],
+          "notes": "MUSC 353 required; select one of MUSC 252, 256, or 354. Required: MUSC 353; remaining are electives"
+        },
+        {
+          "name": "Applied Music Lessons",
+          "description": "Six credits of applied voice lessons",
+          "slots": 6,
+          "credits_per_slot": 1,
+          "eligible_courses": [
+            "MUSC 280K",
+            "MUSC 380K",
+            "MUSC 280A",
+            "MUSC 280AA",
+            "MUSC 280B",
+            "MUSC 280BB",
+            "MUSC 280C",
+            "MUSC 280E",
+            "MUSC 280F",
+            "MUSC 280G",
+            "MUSC 280I",
+            "MUSC 280J",
+            "MUSC 280L",
+            "MUSC 280M",
+            "MUSC 280N",
+            "MUSC 280O",
+            "MUSC 280P",
+            "MUSC 280Q",
+            "MUSC 280R",
+            "MUSC 280S",
+            "MUSC 280U",
+            "MUSC 280V",
+            "MUSC 280Y",
+            "MUSC 280Z",
+            "MUSC 380A",
+            "MUSC 380AA",
+            "MUSC 380B",
+            "MUSC 380BB",
+            "MUSC 380C",
+            "MUSC 380E",
+            "MUSC 380F",
+            "MUSC 380G",
+            "MUSC 380I",
+            "MUSC 380J",
+            "MUSC 380L",
+            "MUSC 380M",
+            "MUSC 380N",
+            "MUSC 380O",
+            "MUSC 380P",
+            "MUSC 380Q",
+            "MUSC 380R",
+            "MUSC 380S",
+            "MUSC 380U",
+            "MUSC 380V",
+            "MUSC 380Y",
+            "MUSC 380Z"
+          ],
+          "notes": "Primary focus on voice (MUSC 280K/380K). Other instruments on case-by-case basis."
+        },
+        {
+          "name": "Ensembles",
+          "description": "Six credits of choral ensemble",
+          "slots": 6,
+          "credits_per_slot": 1,
+          "eligible_courses": [
+            "MUSC 107",
+            "MUSC 207"
+          ],
+          "notes": "Any combination of Chorus (107) and Chamber Choir (207) totaling 6 credits."
+        },
+        {
+          "name": "Required Vocal Performance Courses",
+          "description": "Core vocal performance curriculum",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "eligible_courses_fixed": [
+            {
+              "course": "MUSC 363",
+              "required": true
+            },
+            {
+              "course": "MUSC 364",
+              "required": true
+            },
+            {
+              "course": "MUSC 365",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "Senior Capstone Experience",
+          "description": "Full solo recital required",
+          "slots": 1,
+          "credits_per_slot": 1,
+          "eligible_courses_fixed": [
+            {
+              "course": "MUSC 387",
+              "required": true
+            }
+          ],
+          "notes": "All Vocal Performance students must give a full recital senior year."
+        },
+        {
+          "name": "Music Elective",
+          "description": "Three credits of additional music coursework",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "MUSC 122",
+            "MUSC 185",
+            "MUSC 201",
+            "MUSC 246",
+            "MUSC 247",
+            "MUSC 248",
+            "MUSC 252",
+            "MUSC 255",
+            "MUSC 256",
+            "MUSC 260",
+            "MUSC 345",
+            "MUSC 354",
+            "MUSC 370",
+            "MUSC 374",
+            "MUSC 389",
+            "MUSC 394"
+          ],
+          "notes": "May also use additional 1-credit applied lessons or ensemble courses to reach 3 credits."
+        }
+      ]
+    },
+    {
+      "code": "CHEM-BA",
+      "name": "Chemistry (BA)",
+      "type": "major",
+      "department": "CHEM",
+      "total_credits": 61,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "Uses the new integrated chemistry curriculum (CHEM 160/180/240/260/280 sequence).",
+        "CHEM 361 Principles of Biochemistry does not count toward the CHEM-BA degree.",
+        "CHEM 300 Undergraduate Research is strongly recommended but does not count as elective hours.",
+        "CHEM 300 and CHEM 380 Chemistry Seminar are required for departmental honors.",
+        "Students must complete appropriate mathematics with a grade of C- or better before enrolling in chemistry courses.",
+        "55 credits of required courses plus 6 credits of chemistry electives."
+      ],
+      "categories": [
+        {
+          "name": "General Chemistry",
+          "description": "Introductory chemistry lecture and lab sequence",
+          "slots": 4,
+          "credits_per_slot": null,
+          "total_credits": 8,
+          "eligible_courses": [
+            "CHEM 160",
+            "CHEM 161",
+            "CHEM 180",
+            "CHEM 181"
+          ],
+          "notes": "CHEM 160 (3cr) + CHEM 161 lab (1cr) + CHEM 180 (3cr) + CHEM 181 lab (1cr)"
+        },
+        {
+          "name": "Organic & Analytical Chemistry",
+          "description": "Intermediate chemistry lecture and lab courses",
+          "slots": 5,
+          "credits_per_slot": null,
+          "total_credits": 13,
+          "eligible_courses": [
+            "CHEM 240",
+            "CHEM 242",
+            "CHEM 260",
+            "CHEM 272",
+            "CHEM 280"
+          ],
+          "notes": "CHEM 240 (3cr) + CHEM 242 lab (2cr) + CHEM 260 (3cr) + CHEM 272 lab (2cr) + CHEM 280 (3cr)"
+        },
+        {
+          "name": "Upper-Level Chemistry",
+          "description": "Advanced required chemistry courses",
+          "slots": 5,
+          "credits_per_slot": 3,
+          "total_credits": 15,
+          "eligible_courses": [
+            "CHEM 301",
+            "CHEM 302",
+            "CHEM 303",
+            "CHEM 314",
+            "CHEM 340"
+          ],
+          "notes": "CHEM 301 (3cr) + CHEM 302 (3cr) + CHEM 303 lab (2cr) + CHEM 314 (4cr) + CHEM 340 (3cr). Total is 15cr."
+        },
+        {
+          "name": "Chemistry Electives",
+          "description": "Upper-level chemistry electives",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "CHEM 303",
+            "CHEM 305",
+            "CHEM 306",
+            "CHEM 310",
+            "CHEM 314",
+            "CHEM 317",
+            "CHEM 320",
+            "CHEM 325",
+            "CHEM 330",
+            "CHEM 335",
+            "CHEM 340",
+            "CHEM 341",
+            "CHEM 345",
+            "CHEM 350",
+            "CHEM 355",
+            "CHEM 360",
+            "CHEM 370",
+            "CHEM 375",
+            "CHEM 380",
+            "CHEM 390",
+            "CHEM 395"
+          ],
+          "notes": "Catalog does not enumerate eligible electives. Electives must be CHEM courses; CHEM 361 excluded. CHEM 300/380 do not count. List is approximate — verify against department advising."
+        },
+        {
+          "name": "Physics Sequence",
+          "description": "Calculus-based physics with labs",
+          "slots": 4,
+          "credits_per_slot": null,
+          "total_credits": 8,
+          "eligible_courses": [
+            "PHYS 121",
+            "PHYS 111L",
+            "PHYS 122",
+            "PHYS 112L"
+          ],
+          "notes": "PHYS 121 (3cr) + PHYS 111L lab (1cr) + PHYS 122 (3cr) + PHYS 112L lab (1cr)"
+        },
+        {
+          "name": "Mathematics",
+          "description": "Required math and statistics courses",
+          "slots": 3,
+          "credits_per_slot": null,
+          "total_credits": 11,
+          "eligible_courses": [
+            "MATH 161",
+            "MATH 162",
+            "STAT 203"
+          ],
+          "notes": "MATH 161 (4cr) + MATH 162 (4cr) + STAT 203 (3cr)"
+        }
+      ]
+    },
+    {
+      "code": "CHEM-BS",
+      "name": "Chemistry (BS)",
+      "type": "major",
+      "department": "CHEM",
+      "total_credits": 65,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "ACS-accredited program. Uses the new integrated chemistry curriculum.",
+        "CHEM 361 Principles of Biochemistry does not count toward the CHEM-BS degree.",
+        "CHEM 300 Undergraduate Research is strongly recommended but does not count as elective hours.",
+        "CHEM 300 and CHEM 380 Chemistry Seminar are required for departmental honors.",
+        "Students must complete appropriate mathematics with a grade of C- or better before enrolling in chemistry courses.",
+        "Includes CHEM 370 Biochemistry I (required) and CHEM 341 Advanced Inorganic Lab (not in BA)."
+      ],
+      "categories": [
+        {
+          "name": "General Chemistry",
+          "description": "Introductory chemistry lecture and lab sequence",
+          "slots": 4,
+          "credits_per_slot": null,
+          "total_credits": 8,
+          "eligible_courses": [
+            "CHEM 160",
+            "CHEM 161",
+            "CHEM 180",
+            "CHEM 181"
+          ],
+          "notes": "CHEM 160 (3cr) + CHEM 161 lab (1cr) + CHEM 180 (3cr) + CHEM 181 lab (1cr)"
+        },
+        {
+          "name": "Organic & Analytical Chemistry",
+          "description": "Intermediate chemistry lecture and lab courses",
+          "slots": 5,
+          "credits_per_slot": null,
+          "total_credits": 13,
+          "eligible_courses": [
+            "CHEM 240",
+            "CHEM 242",
+            "CHEM 260",
+            "CHEM 272",
+            "CHEM 280"
+          ],
+          "notes": "CHEM 240 (3cr) + CHEM 242 lab (2cr) + CHEM 260 (3cr) + CHEM 272 lab (2cr) + CHEM 280 (3cr)"
+        },
+        {
+          "name": "Upper-Level Chemistry",
+          "description": "Advanced required chemistry courses including biochemistry and inorganic lab",
+          "slots": 7,
+          "credits_per_slot": null,
+          "total_credits": 19,
+          "eligible_courses": [
+            "CHEM 301",
+            "CHEM 302",
+            "CHEM 303",
+            "CHEM 314",
+            "CHEM 340",
+            "CHEM 341",
+            "CHEM 370"
+          ],
+          "notes": "CHEM 301 (3cr) + CHEM 302 (3cr) + CHEM 303 lab (2cr) + CHEM 314 (4cr) + CHEM 340 (3cr) + CHEM 341 lab (1cr) + CHEM 370 Biochemistry I (3cr)"
+        },
+        {
+          "name": "Chemistry Electives",
+          "description": "Upper-level chemistry electives",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "CHEM 305",
+            "CHEM 306",
+            "CHEM 310",
+            "CHEM 317",
+            "CHEM 320",
+            "CHEM 325",
+            "CHEM 330",
+            "CHEM 335",
+            "CHEM 345",
+            "CHEM 350",
+            "CHEM 355",
+            "CHEM 360",
+            "CHEM 375",
+            "CHEM 390",
+            "CHEM 395"
+          ],
+          "notes": "Catalog does not enumerate eligible electives. Electives must be CHEM courses; CHEM 361 excluded. CHEM 300/380 do not count. List is approximate — verify against department advising."
+        },
+        {
+          "name": "Physics Sequence",
+          "description": "Calculus-based physics with labs",
+          "slots": 4,
+          "credits_per_slot": null,
+          "total_credits": 8,
+          "eligible_courses": [
+            "PHYS 121",
+            "PHYS 111L",
+            "PHYS 122",
+            "PHYS 112L"
+          ],
+          "notes": "PHYS 121 (3cr) + PHYS 111L lab (1cr) + PHYS 122 (3cr) + PHYS 112L lab (1cr)"
+        },
+        {
+          "name": "Mathematics",
+          "description": "Required math and statistics courses",
+          "slots": 3,
+          "credits_per_slot": null,
+          "total_credits": 11,
+          "eligible_courses": [
+            "MATH 161",
+            "MATH 162",
+            "STAT 203"
+          ],
+          "notes": "MATH 161 (4cr) + MATH 162 (4cr) + STAT 203 (3cr)"
+        }
+      ]
+    },
+    {
+      "code": "PHYS-BS",
+      "name": "Physics (BS)",
+      "type": "major",
+      "department": "PHYS",
+      "total_credits": 55,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "A minimum grade of C- must be earned to satisfy a course requirement.",
+        "2.0 minimum overall GPA required.",
+        "Total credits: 8 (intro physics) + 32 (upper physics) + 15 (math) = 55 major credits."
+      ],
+      "categories": [
+        {
+          "name": "Introductory Physics",
+          "description": "Calculus-based physics with labs",
+          "slots": 4,
+          "credits_per_slot": null,
+          "total_credits": 8,
+          "eligible_courses": [
+            "PHYS 121",
+            "PHYS 111L",
+            "PHYS 122",
+            "PHYS 112L"
+          ],
+          "notes": "PHYS 121 (3cr) + PHYS 111L lab (1cr) + PHYS 122 (3cr) + PHYS 112L lab (1cr)"
+        },
+        {
+          "name": "Required Physics Courses",
+          "description": "Core upper-level physics lecture and lab courses",
+          "slots": 14,
+          "credits_per_slot": null,
+          "total_credits": 32,
+          "eligible_courses": [
+            "PHYS 126F",
+            "PHYS 130",
+            "PHYS 235",
+            "PHYS 235L",
+            "PHYS 301",
+            "PHYS 303",
+            "PHYS 303L",
+            "PHYS 310",
+            "PHYS 310L",
+            "PHYS 314",
+            "PHYS 328",
+            "PHYS 338",
+            "PHYS 351",
+            "PHYS 361"
+          ],
+          "notes": "PHYS 126F (1cr) + PHYS 130 (3cr) + PHYS 235 (3cr) + PHYS 235L (1cr) + PHYS 301 (3cr) + PHYS 303 (3cr) + PHYS 303L (1cr) + PHYS 310 (3cr) + PHYS 310L (1cr) + PHYS 314 (3cr) + PHYS 328 (3cr) + PHYS 338 (2cr) + PHYS 351 (3cr) + PHYS 361 (3cr)"
+        },
+        {
+          "name": "Mathematics",
+          "description": "Required calculus and differential equations sequence",
+          "slots": 4,
+          "credits_per_slot": null,
+          "total_credits": 15,
+          "eligible_courses": [
+            "MATH 161",
+            "MATH 162",
+            "MATH 263",
+            "MATH 264"
+          ],
+          "notes": "MATH 161 (4cr) + MATH 162 (4cr) + MATH 263 (4cr) + MATH 264 (3cr)"
+        }
+      ]
+    },
+    {
+      "code": "PHYS-BS-BIOP",
+      "name": "Biophysics (BS)",
+      "type": "major",
+      "department": "PHYS",
+      "total_credits": 68,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "A minimum grade of C- must be earned to satisfy a course requirement.",
+        "2.0 minimum overall GPA required.",
+        "Students may receive degree credit for only one of: BIOL 102, COMP 180, or PHYS 130.",
+        "Only 1 credit hour of PHYS 391 Research may count toward the degree.",
+        "Chemistry requirements use old-style course codes (CHEM 101/102, CHEM 223/224).",
+        "Total ~67-69 credits depending on biology foundation choice."
+      ],
+      "categories": [
+        {
+          "name": "Introductory Physics",
+          "description": "Calculus-based physics with labs",
+          "slots": 5,
+          "credits_per_slot": null,
+          "total_credits": 9,
+          "eligible_courses": [
+            "PHYS 121",
+            "PHYS 111L",
+            "PHYS 122",
+            "PHYS 112L",
+            "PHYS 126F"
+          ],
+          "notes": "PHYS 121 (3cr) + PHYS 111L (1cr) + PHYS 122 (3cr) + PHYS 112L (1cr) + PHYS 126F (1cr)"
+        },
+        {
+          "name": "Upper-Level Physics",
+          "description": "Required upper-level physics courses",
+          "slots": 5,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "PHYS 235",
+            "PHYS 235L",
+            "PHYS 301",
+            "PHYS 314",
+            "PHYS 351"
+          ],
+          "notes": "PHYS 235 (3cr) + PHYS 235L (1cr) + PHYS 301 (3cr) + PHYS 314 (3cr) + PHYS 351 (3cr). Total 13cr."
+        },
+        {
+          "name": "Physics Elective",
+          "description": "Select one upper-level physics elective",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "PHYS 310",
+            "PHYS 328",
+            "PHYS 361"
+          ]
+        },
+        {
+          "name": "Biology Foundation",
+          "description": "Select one biology foundation course (some include labs)",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "BIOL 101",
+            "BIOL 251",
+            "BIOL 282"
+          ],
+          "notes": "BIOL 101 requires BIOL 111 lab (1cr additional). BIOL 251 and BIOL 282 are 3cr each."
+        },
+        {
+          "name": "Biophysics Electives",
+          "description": "Select courses totaling 10 credit hours",
+          "slots": 3,
+          "credits_per_slot": 3,
+          "total_credits": 10,
+          "eligible_courses": [
+            "BIOL 102",
+            "BIOL 111",
+            "BIOL 112",
+            "BIOL 252",
+            "BIOL 283",
+            "BIOL 317",
+            "BIOL 335",
+            "BIOL 366",
+            "BIOL 366L",
+            "BIOL 382",
+            "BIOL 387",
+            "BIOL 388",
+            "BIOL 390",
+            "COMP 180",
+            "PHYS 130",
+            "PHYS 310L",
+            "PHYS 338",
+            "PHYS 371",
+            "PHYS 391"
+          ],
+          "notes": "Must total 10 credit hours. Only 1cr of PHYS 391 allowed. Only one of BIOL 102, COMP 180, or PHYS 130 may count."
+        },
+        {
+          "name": "General Chemistry",
+          "description": "General chemistry lecture and lab sequence",
+          "slots": 4,
+          "credits_per_slot": null,
+          "total_credits": 8,
+          "eligible_courses": [
+            "CHEM 101",
+            "CHEM 111",
+            "CHEM 102",
+            "CHEM 112"
+          ],
+          "notes": "CHEM 101 (3cr) + CHEM 111 lab (1cr) + CHEM 102 (3cr) + CHEM 112 lab (1cr). CHEM 106 may substitute for CHEM 102."
+        },
+        {
+          "name": "Organic Chemistry",
+          "description": "Organic chemistry lecture and lab sequence",
+          "slots": 4,
+          "credits_per_slot": null,
+          "total_credits": 8,
+          "eligible_courses": [
+            "CHEM 223",
+            "CHEM 225",
+            "CHEM 224",
+            "CHEM 226"
+          ],
+          "notes": "CHEM 223 (3cr) + CHEM 225 lab (1cr) + CHEM 224 (3cr) + CHEM 226 lab (1cr). CHEM 221 may substitute for CHEM 223; CHEM 222 may substitute for CHEM 224."
+        },
+        {
+          "name": "Mathematics",
+          "description": "Required calculus and differential equations sequence",
+          "slots": 4,
+          "credits_per_slot": null,
+          "total_credits": 15,
+          "eligible_courses": [
+            "MATH 161",
+            "MATH 162",
+            "MATH 263",
+            "MATH 264"
+          ],
+          "notes": "MATH 161 (4cr) + MATH 162 (4cr) + MATH 263 (4cr) + MATH 264 (3cr)"
+        }
+      ]
+    },
+    {
+      "code": "PHYS-BS-COMP",
+      "name": "Physics with Computer Science (BS)",
+      "type": "major",
+      "department": "PHYS",
+      "total_credits": 75,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "A minimum grade of C- must be earned to satisfy a course requirement.",
+        "2.0 minimum overall GPA required.",
+        "Interdisciplinary program combining physics and computer science.",
+        "Total: 29 (physics) + 15 (math) + 15 (CS required) + 3 (discrete math) + 3 (CS choice) + 6 (300-level electives) = 71-75 credits."
+      ],
+      "categories": [
+        {
+          "name": "Introductory Physics",
+          "description": "Calculus-based physics with labs and freshman projects",
+          "slots": 5,
+          "credits_per_slot": null,
+          "total_credits": 9,
+          "eligible_courses": [
+            "PHYS 121",
+            "PHYS 111L",
+            "PHYS 122",
+            "PHYS 112L",
+            "PHYS 126F"
+          ],
+          "notes": "PHYS 121 (3cr) + PHYS 111L (1cr) + PHYS 122 (3cr) + PHYS 112L (1cr) + PHYS 126F (1cr)"
+        },
+        {
+          "name": "Upper-Level Physics",
+          "description": "Required upper-level physics courses",
+          "slots": 10,
+          "credits_per_slot": null,
+          "total_credits": 24,
+          "eligible_courses": [
+            "PHYS 235",
+            "PHYS 235L",
+            "PHYS 301",
+            "PHYS 303",
+            "PHYS 303L",
+            "PHYS 310",
+            "PHYS 310L",
+            "PHYS 314",
+            "PHYS 351",
+            "PHYS 361"
+          ],
+          "notes": "PHYS 235 (3cr) + PHYS 235L (1cr) + PHYS 301 (3cr) + PHYS 303 (3cr) + PHYS 303L (1cr) + PHYS 310 (3cr) + PHYS 310L (1cr) + PHYS 314 (3cr) + PHYS 351 (3cr) + PHYS 361 (3cr)"
+        },
+        {
+          "name": "Computer Science Core",
+          "description": "Required computer science courses",
+          "slots": 5,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "COMP 141",
+            "COMP 170",
+            "COMP 264",
+            "COMP 271",
+            "COMP 272"
+          ]
+        },
+        {
+          "name": "Discrete Mathematics",
+          "description": "Select one discrete math course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "COMP 163",
+            "MATH 201"
+          ]
+        },
+        {
+          "name": "Computer Science Elective",
+          "description": "Select one advanced CS course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "COMP 313",
+            "COMP 363"
+          ]
+        },
+        {
+          "name": "300-Level Interdisciplinary Electives",
+          "description": "Select two 300-level electives from approved list",
+          "slots": 2,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "BIOL 388",
+            "BIOL 392",
+            "MATH 309",
+            "MATH 328",
+            "MATH 331",
+            "PHYS 328",
+            "PHYS 338",
+            "STAT 321"
+          ],
+          "notes": "Any COMP 300-level course also eligible. Only specific non-COMP courses listed here."
+        },
+        {
+          "name": "Mathematics",
+          "description": "Required calculus and differential equations sequence",
+          "slots": 4,
+          "credits_per_slot": null,
+          "total_credits": 15,
+          "eligible_courses": [
+            "MATH 161",
+            "MATH 162",
+            "MATH 263",
+            "MATH 264"
+          ],
+          "notes": "MATH 161 (4cr) + MATH 162 (4cr) + MATH 263 (4cr) + MATH 264 (3cr)"
+        }
+      ]
+    },
+    {
+      "code": "PHYS-BS-TPAM",
+      "name": "Theoretical Physics and Applied Mathematics (BS)",
+      "type": "major",
+      "department": "PHYS",
+      "total_credits": 63,
+      "unique_credits_required": 21,
+      "double_dip_policy": "CAS_DEFAULT",
+      "notes": [
+        "Interdisciplinary program providing extensive training in both physics and mathematics.",
+        "A minimum grade of C- must be earned to satisfy a course requirement.",
+        "2.0 minimum overall GPA required.",
+        "Total: 29 (math) + 34 (physics) = 63 credits."
+      ],
+      "categories": [
+        {
+          "name": "Mathematics Core",
+          "description": "Required mathematics courses including calculus, algebra, and analysis",
+          "slots": 9,
+          "credits_per_slot": null,
+          "total_credits": 29,
+          "eligible_courses": [
+            "MATH 161",
+            "MATH 162",
+            "MATH 201",
+            "MATH 212",
+            "MATH 263",
+            "MATH 264",
+            "MATH 313",
+            "MATH 351",
+            "MATH 353"
+          ],
+          "notes": "MATH 161 (4cr) + MATH 162 (4cr) + MATH 201 (3cr) + MATH 212 (3cr) + MATH 263 (4cr) + MATH 264 (3cr) + MATH 313 (3cr) + MATH 351 (3cr) + MATH 353 (3cr). Includes one computational choice."
+        },
+        {
+          "name": "Computational Methods",
+          "description": "Select one computational course",
+          "slots": 1,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "PHYS 130",
+            "MATH 215"
+          ]
+        },
+        {
+          "name": "Introductory Physics",
+          "description": "Calculus-based physics with labs and freshman projects",
+          "slots": 5,
+          "credits_per_slot": null,
+          "total_credits": 9,
+          "eligible_courses": [
+            "PHYS 121",
+            "PHYS 111L",
+            "PHYS 122",
+            "PHYS 112L",
+            "PHYS 126F"
+          ],
+          "notes": "PHYS 121 (3cr) + PHYS 111L (1cr) + PHYS 122 (3cr) + PHYS 112L (1cr) + PHYS 126F (1cr)"
+        },
+        {
+          "name": "Upper-Level Physics",
+          "description": "Required upper-level physics lecture courses",
+          "slots": 6,
+          "credits_per_slot": 3,
+          "eligible_courses": [
+            "PHYS 235",
+            "PHYS 301",
+            "PHYS 314",
+            "PHYS 328",
+            "PHYS 351",
+            "PHYS 361"
+          ],
+          "notes": "PHYS 235 (3cr) + PHYS 301 (3cr) + PHYS 314 (3cr) + PHYS 328 (3cr) + PHYS 351 (3cr) + PHYS 361 (3cr)"
+        },
+        {
+          "name": "Physics Labs",
+          "description": "Required physics laboratory courses",
+          "slots": 3,
+          "credits_per_slot": null,
+          "total_credits": 4,
+          "eligible_courses": [
+            "PHYS 235L",
+            "PHYS 338"
+          ],
+          "notes": "PHYS 235L (1cr) + PHYS 338 (2cr). Note PHYS 338 is Advanced Physics Lab, 2 credits."
+        }
+      ]
     }
   ],
   "overlap_rules": {
@@ -1656,6 +9875,31 @@
     ],
     "FNAR-BA": [
       "Artistic Knowledge and Inquiry"
+    ],
+    "MATH-BS": [
+      "Quantitative Knowledge and Inquiry",
+      "Scientific Knowledge and Inquiry"
+    ],
+    "MATH-BS-APPL": [
+      "Quantitative Knowledge and Inquiry",
+      "Scientific Knowledge and Inquiry"
+    ],
+    "MATH-BS-COMP": [
+      "Quantitative Knowledge and Inquiry"
+    ],
+    "STAT-BS": [
+      "Quantitative Knowledge and Inquiry",
+      "Scientific Knowledge and Inquiry"
+    ],
+    "PSYC-BS": [
+      "Societal/Cultural",
+      "Quantitative"
+    ],
+    "SOCL-BA": [
+      "Societal/Cultural"
+    ],
+    "SOCL-BA-ANTH": [
+      "Societal/Cultural"
     ]
   }
 }


### PR DESCRIPTION
## Summary
Add full requirement definitions for 56 CAS degree programs, bringing the total from 12 to 68 modeled programs. Requirements scraped from catalog.luc.edu using parallel agents (7 batches).

**By batch:**
- 13 Humanities BAs (AFR, ARHI, CLST, DANC, ENGL-CW, FREN, GREK, ITAL, ITST, LATN, RELS, THTR, WSGS)
- 6 Social Sciences (ECON, CJC, PSYC, SOCL, SOCL-ANTH, HMSR)
- 5 Music & Fine Arts (FNAR-VC, MUSC + 3 concentrations)
- 5 Environmental Studies (ENVS-BA + 3 concentrations + ENVS-BS)
- 8 Life Sciences (BCHM-BA/BS, BIOL-BS + 2 emphases, FRSC, NEUR-CB/MC)
- 13 Math/CS/Engineering (COMP, CYBR, DSCI, SWEN, INFT-BA/BS, MATH + 2 concentrations, STAT, ENGR × 3)
- 6 Physical Sciences (CHEM-BA/BS, PHYS-BS + 3 concentrations)

**Stats:** 430 categories, 3,543 eligible course mappings, seeded successfully.

Fixes #58, Fixes #59, Fixes #60, Fixes #61, Fixes #62, Fixes #63, Fixes #64

## Test plan
- [ ] `npm run db:seed-programs` succeeds (68 programs, 430 categories)
- [ ] `GET /api/programs` returns 68 programs
- [ ] Declare a new program (e.g., COMP-BS) on a test account → solver returns categories
- [ ] Existing programs (PLSC-BA, GLST-BA, etc.) unchanged
- [ ] Spot-check 2-3 programs against catalog.luc.edu for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)