### PR TITLE
RMP match correction UI for admin panel

### DIFF
--- a/client/src/pages/AdminPanel.jsx
+++ b/client/src/pages/AdminPanel.jsx
@@ -1317,6 +1317,173 @@ function ToolsTab() {
 
       {/* RateMyProfessor Ratings */}
       <RmpToolCard />
+
+      {/* RMP Match Review */}
+      <RmpMatchReview />
+    </div>
+  );
+}
+
+function RmpMatchReview() {
+  const [matches, setMatches] = useState([]);
+  const [total, setTotal] = useState(0);
+  const [quality, setQuality] = useState("auto");
+  const [search, setSearch] = useState("");
+  const [offset, setOffset] = useState(0);
+  const [searchingFor, setSearchingFor] = useState(null); // { id, instructorName }
+  const [rmpResults, setRmpResults] = useState([]);
+  const [rmpSearchQuery, setRmpSearchQuery] = useState("");
+  const [rmpSearching, setRmpSearching] = useState(false);
+  const [hasSearched, setHasSearched] = useState(false);
+  const limit = 50;
+
+  const loadMatches = useCallback(async () => {
+    const params = new URLSearchParams({ quality, limit, offset });
+    if (search) params.set("q", search);
+    const data = await api.get(`/api/admin/rmp-matches?${params}`);
+    setMatches(data.matches || []);
+    setTotal(data.total || 0);
+  }, [quality, search, offset]);
+
+  useEffect(() => { loadMatches(); }, [loadMatches]);
+
+  const updateMatch = async (id, rmpId, matchQuality) => {
+    await api.put(`/api/admin/rmp-matches/${id}`, { rmpId, matchQuality });
+    loadMatches();
+  };
+
+  const doRmpSearch = async () => {
+    if (!rmpSearchQuery.trim()) return;
+    setRmpSearching(true);
+    const results = await api.get(`/api/admin/rmp-search?name=${encodeURIComponent(rmpSearchQuery)}`);
+    setRmpResults(Array.isArray(results) ? results : []);
+    setRmpSearching(false);
+    setHasSearched(true);
+  };
+
+  const linkProfessor = async (matchId, prof) => {
+    await api.put(`/api/admin/rmp-matches/${matchId}`, { rmpId: prof.rmpId, matchQuality: "manual", professorData: prof });
+    setSearchingFor(null);
+    setRmpResults([]);
+    loadMatches();
+  };
+
+  const qualityBadge = (q) => {
+    const colors = { auto: ["#fff3cd", "#856404"], manual: ["#e8f5e9", "#22863a"], none: ["#f0f0f0", "#888"] };
+    const [bg, color] = colors[q] || colors.none;
+    return { fontFamily: FONT.mono, fontSize: TYPE.xs, padding: "2px 6px", borderRadius: 3, background: bg, color };
+  };
+
+  const btnStyle = (bg) => ({
+    fontFamily: FONT.mono, fontSize: TYPE.xs, padding: "3px 8px", borderRadius: 3,
+    background: bg, color: "#fff", border: "none", cursor: "pointer",
+  });
+
+  return (
+    <div style={{ background: "#fff", border: `1px solid ${BORDER}`, borderRadius: 8, padding: "1rem", marginTop: "0.75rem" }}>
+      <div style={{ fontFamily: FONT.serif, fontSize: TYPE.md, fontWeight: 600, marginBottom: "0.5rem" }}>
+        Review RMP Matches
+      </div>
+      <p style={{ fontFamily: FONT.mono, fontSize: TYPE.sm, color: "#666", marginBottom: "0.75rem", lineHeight: 1.5 }}>
+        Review auto-matched professors. Confirm correct matches, break wrong ones, or search RMP to link manually.
+      </p>
+
+      {/* Filters */}
+      <div style={{ display: "flex", gap: "0.5rem", marginBottom: "0.75rem", flexWrap: "wrap" }}>
+        <select value={quality} onChange={e => { setQuality(e.target.value); setOffset(0); }}
+          style={{ fontFamily: FONT.mono, fontSize: TYPE.sm, padding: "0.3rem 0.5rem", border: `1px solid ${BORDER}`, borderRadius: 4, background: "#fafaf8" }}>
+          <option value="all">All</option>
+          <option value="auto">Auto-matched</option>
+          <option value="manual">Manually linked</option>
+          <option value="none">Unmatched</option>
+        </select>
+        <input type="text" placeholder="Search instructor..." value={search}
+          onChange={e => { setSearch(e.target.value); setOffset(0); }}
+          style={{ fontFamily: FONT.mono, fontSize: TYPE.sm, padding: "0.3rem 0.5rem", border: `1px solid ${BORDER}`, borderRadius: 4, background: "#fafaf8", flex: 1, minWidth: 150 }} />
+        <span style={{ fontFamily: FONT.mono, fontSize: TYPE.xs, color: "#888", alignSelf: "center" }}>
+          {total} matches
+        </span>
+      </div>
+
+      {/* Match list */}
+      <div style={{ maxHeight: 400, overflow: "auto" }}>
+        {matches.map(m => (
+          <div key={m.id} style={{ display: "flex", alignItems: "center", gap: "0.5rem", padding: "0.4rem 0", borderBottom: `1px solid ${BORDER}`, flexWrap: "wrap" }}>
+            <div style={{ flex: 1, minWidth: 140 }}>
+              <div style={{ fontFamily: FONT.mono, fontSize: TYPE.sm, fontWeight: 600 }}>{m.instructor_name}</div>
+              {m.rmp_id && (
+                <div style={{ fontFamily: FONT.mono, fontSize: TYPE.xs, color: "#666" }}>
+                  → {m.rmp_first_name} {m.rmp_last_name} {m.rmp_department && `(${m.rmp_department})`} {m.rmp_rating != null && `★${m.rmp_rating}`} {m.rmp_num_ratings != null && `(${m.rmp_num_ratings})`}
+                </div>
+              )}
+              {!m.rmp_id && <div style={{ fontFamily: FONT.mono, fontSize: TYPE.xs, color: "#bbb" }}>No match</div>}
+            </div>
+            <span style={qualityBadge(m.match_quality)}>{m.match_quality}</span>
+            <div style={{ display: "flex", gap: "0.3rem" }}>
+              {m.match_quality === "auto" && (
+                <>
+                  <button onClick={() => updateMatch(m.id, m.rmp_id, "manual")} style={btnStyle("#22863a")}>Confirm</button>
+                  <button onClick={() => updateMatch(m.id, null, "none")} style={btnStyle("#c43b2d")}>Break</button>
+                </>
+              )}
+              {m.match_quality === "manual" && (
+                <button onClick={() => updateMatch(m.id, null, "none")} style={btnStyle("#c43b2d")}>Break</button>
+              )}
+              {(m.match_quality === "none" || !m.rmp_id) && (
+                <button onClick={() => { setSearchingFor({ id: m.id, instructorName: m.instructor_name }); setRmpSearchQuery(m.instructor_name); setRmpResults([]); setHasSearched(false); }} style={btnStyle("#6f42c1")}>Search & Link</button>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Pagination */}
+      {total > limit && (
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginTop: "0.5rem" }}>
+          <button disabled={offset === 0} onClick={() => setOffset(Math.max(0, offset - limit))}
+            style={{ ...btnStyle("#5a6a7a"), opacity: offset === 0 ? 0.4 : 1 }}>← Prev</button>
+          <span style={{ fontFamily: FONT.mono, fontSize: TYPE.xs, color: "#888" }}>
+            {offset + 1}–{Math.min(offset + limit, total)} of {total}
+          </span>
+          <button disabled={offset + limit >= total} onClick={() => setOffset(offset + limit)}
+            style={{ ...btnStyle("#5a6a7a"), opacity: offset + limit >= total ? 0.4 : 1 }}>Next →</button>
+        </div>
+      )}
+
+      {/* RMP Search panel */}
+      {searchingFor && (
+        <div style={{ background: "#f8f6f2", border: `1px solid ${BORDER}`, borderRadius: 8, padding: "0.75rem", marginTop: "0.75rem" }}>
+          <div style={{ fontFamily: FONT.mono, fontSize: TYPE.sm, fontWeight: 600, marginBottom: "0.4rem" }}>
+            Search RMP for: {searchingFor.instructorName}
+          </div>
+          <div style={{ display: "flex", gap: "0.3rem", marginBottom: "0.5rem" }}>
+            <input type="text" value={rmpSearchQuery} onChange={e => setRmpSearchQuery(e.target.value)}
+              onKeyDown={e => e.key === "Enter" && doRmpSearch()}
+              style={{ fontFamily: FONT.mono, fontSize: TYPE.sm, padding: "0.3rem 0.5rem", border: `1px solid ${BORDER}`, borderRadius: 4, background: "#fff", flex: 1 }} />
+            <button onClick={doRmpSearch} disabled={rmpSearching} style={btnStyle("#6f42c1")}>
+              {rmpSearching ? "..." : "Search"}
+            </button>
+            <button onClick={() => { setSearchingFor(null); setRmpResults([]); }} style={btnStyle("#888")}>Cancel</button>
+          </div>
+          {rmpResults.length > 0 && (
+            <div style={{ display: "flex", flexDirection: "column", gap: "0.3rem" }}>
+              {rmpResults.map(r => (
+                <div key={r.rmpId} style={{ display: "flex", alignItems: "center", gap: "0.5rem", padding: "0.3rem 0.5rem", background: "#fff", borderRadius: 4, border: `1px solid ${BORDER}` }}>
+                  <div style={{ flex: 1 }}>
+                    <span style={{ fontFamily: FONT.mono, fontSize: TYPE.sm, fontWeight: 600 }}>{r.firstName} {r.lastName}</span>
+                    <span style={{ fontFamily: FONT.mono, fontSize: TYPE.xs, color: "#888", marginLeft: "0.5rem" }}>{r.department || ""}</span>
+                    <span style={{ fontFamily: FONT.mono, fontSize: TYPE.xs, color: "#888", marginLeft: "0.5rem" }}>★{r.rating} ({r.numRatings})</span>
+                  </div>
+                  <button onClick={() => linkProfessor(searchingFor.id, r)} style={btnStyle("#22863a")}>Link</button>
+                </div>
+              ))}
+            </div>
+          )}
+          {rmpResults.length === 0 && hasSearched && !rmpSearching && (
+            <div style={{ fontFamily: FONT.mono, fontSize: TYPE.xs, color: "#888" }}>No results — try a different name</div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/server/lib/rmp.js
+++ b/server/lib/rmp.js
@@ -1,0 +1,101 @@
+/**
+ * server/lib/rmp.js
+ * Shared RMP (RateMyProfessor) search and upsert helpers.
+ * Used by both scrape-rmp.js and admin.js endpoints.
+ */
+
+const { GraphQLClient, gql } = require("graphql-request");
+
+const RMP_URL = "https://www.ratemyprofessors.com/graphql";
+const RMP_AUTH = "Basic dGVzdDp0ZXN0"; // public auth token used by RMP's own frontend
+
+const SEARCH_SCHOOL = gql`
+  query SearchSchools($query: SchoolSearchQuery!) {
+    newSearch { schools(query: $query) { edges { node { id name city state } } } }
+  }
+`;
+
+const SEARCH_TEACHER = gql`
+  query SearchTeachers($text: String!, $schoolID: ID!) {
+    newSearch {
+      teachers(query: { text: $text, schoolID: $schoolID }) {
+        edges {
+          node {
+            id firstName lastName department
+            avgRating avgDifficulty numRatings
+            wouldTakeAgainPercent legacyId
+            school { id name }
+          }
+        }
+      }
+    }
+  }
+`;
+
+let lucSchoolId = null;
+
+/**
+ * Find the LUC school ID on RMP (cached after first call).
+ */
+async function getLucSchoolId() {
+  if (lucSchoolId) return lucSchoolId;
+  const client = new GraphQLClient(RMP_URL, { headers: { Authorization: RMP_AUTH } });
+  const data = await client.request(SEARCH_SCHOOL, { query: { text: "Loyola University Chicago" } });
+  const luc = data.newSearch.schools.edges.find(e =>
+    e.node.name === "Loyola University Chicago" && e.node.state === "IL"
+  )?.node;
+  if (!luc) throw new Error("LUC not found on RMP");
+  lucSchoolId = luc.id;
+  return lucSchoolId;
+}
+
+/**
+ * Search RMP for professors matching a name at LUC.
+ * @param {string} name — professor name to search
+ * @returns {Array} — array of { rmpId, firstName, lastName, department, rating, difficulty, wouldTakeAgain, numRatings, url }
+ */
+async function searchRmpProfessors(name) {
+  const schoolID = await getLucSchoolId();
+  const client = new GraphQLClient(RMP_URL, { headers: { Authorization: RMP_AUTH } });
+  const data = await client.request(SEARCH_TEACHER, { text: name, schoolID });
+  const teachers = (data.newSearch?.teachers?.edges || []).map(e => e.node);
+  return teachers.slice(0, 10).map(t => ({
+    rmpId: String(t.id),
+    firstName: t.firstName,
+    lastName: t.lastName,
+    department: t.department || null,
+    rating: t.avgRating,
+    difficulty: t.avgDifficulty,
+    wouldTakeAgain: t.wouldTakeAgainPercent >= 0 ? t.wouldTakeAgainPercent : null,
+    numRatings: t.numRatings,
+    url: `https://www.ratemyprofessors.com/professor/${t.legacyId}`,
+  }));
+}
+
+/**
+ * Upsert a professor rating into the professor_ratings table.
+ * @param {object} db — better-sqlite3 database instance
+ * @param {object} prof — { rmpId, firstName, lastName, department, rating, difficulty, wouldTakeAgain, numRatings, url }
+ */
+function upsertProfessorRating(db, prof) {
+  db.prepare(`
+    INSERT INTO professor_ratings (rmp_id, first_name, last_name, department,
+      overall_rating, difficulty, would_take_again, num_ratings, rmp_url, scraped_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+    ON CONFLICT(rmp_id) DO UPDATE SET
+      first_name = excluded.first_name,
+      last_name = excluded.last_name,
+      department = excluded.department,
+      overall_rating = excluded.overall_rating,
+      difficulty = excluded.difficulty,
+      would_take_again = excluded.would_take_again,
+      num_ratings = excluded.num_ratings,
+      rmp_url = excluded.rmp_url,
+      scraped_at = datetime('now')
+  `).run(
+    prof.rmpId, prof.firstName, prof.lastName, prof.department,
+    prof.rating, prof.difficulty, prof.wouldTakeAgain, prof.numRatings, prof.url
+  );
+}
+
+module.exports = { searchRmpProfessors, upsertProfessorRating, getLucSchoolId, SEARCH_TEACHER, RMP_URL, RMP_AUTH };

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -330,4 +330,82 @@ router.get("/rmp-scrape/status", (req, res) => {
   res.json({ ...rmpJob, stats });
 });
 
+// ── RMP Match Review ────────────────────────────────────────────────────────
+
+// GET /api/admin/rmp-matches — list all instructor matches with professor data
+router.get("/rmp-matches", (req, res) => {
+  const quality = req.query.quality || "all";
+  const search = req.query.q || "";
+  const limit = Math.min(parseInt(req.query.limit) || 100, 500);
+  const offset = parseInt(req.query.offset) || 0;
+
+  let where = "1=1";
+  const params = [];
+  if (quality !== "all") {
+    if (quality === "none") {
+      where += " AND (irm.match_quality = 'none' OR irm.rmp_id IS NULL)";
+    } else {
+      where += " AND irm.match_quality = ?";
+      params.push(quality);
+    }
+  }
+  if (search) {
+    where += " AND irm.instructor_name LIKE ?";
+    params.push(`%${search}%`);
+  }
+
+  const rows = db.prepare(`
+    SELECT irm.id, irm.instructor_name, irm.rmp_id, irm.match_quality,
+           pr.first_name AS rmp_first_name, pr.last_name AS rmp_last_name,
+           pr.department AS rmp_department, pr.overall_rating AS rmp_rating,
+           pr.num_ratings AS rmp_num_ratings, pr.rmp_url
+    FROM instructor_rmp_matches irm
+    LEFT JOIN professor_ratings pr ON pr.rmp_id = irm.rmp_id
+    WHERE ${where}
+    ORDER BY CASE irm.match_quality WHEN 'auto' THEN 0 WHEN 'manual' THEN 1 ELSE 2 END, irm.instructor_name
+    LIMIT ? OFFSET ?
+  `).all(...params, limit, offset);
+
+  const total = db.prepare(`SELECT COUNT(*) as c FROM instructor_rmp_matches irm WHERE ${where}`).get(...params).c;
+
+  res.json({ matches: rows, total, limit, offset });
+});
+
+// PUT /api/admin/rmp-matches/:id — correct a match
+router.put("/rmp-matches/:id", (req, res) => {
+  const { rmpId, matchQuality, professorData } = req.body;
+  if (!matchQuality || !["manual", "none"].includes(matchQuality)) {
+    return res.status(400).json({ error: "matchQuality must be 'manual' or 'none'" });
+  }
+
+  // If linking to a professor, ensure their rating data exists in professor_ratings
+  if (rmpId && matchQuality === "manual" && professorData) {
+    const { upsertProfessorRating } = require("../lib/rmp");
+    upsertProfessorRating(db, professorData);
+  }
+
+  const result = db.prepare(`
+    UPDATE instructor_rmp_matches SET rmp_id = ?, match_quality = ? WHERE id = ?
+  `).run(rmpId || null, matchQuality, req.params.id);
+
+  if (result.changes === 0) {
+    return res.status(404).json({ error: "Match not found" });
+  }
+  res.json({ ok: true });
+});
+
+// GET /api/admin/rmp-search — search RMP for a professor
+router.get("/rmp-search", async (req, res) => {
+  const name = req.query.name;
+  if (!name) return res.status(400).json({ error: "name query param required" });
+
+  try {
+    const { searchRmpProfessors } = require("../lib/rmp");
+    const results = await searchRmpProfessors(name);
+    res.json(results);
+  } catch (e) {
+    res.status(502).json({ error: "RMP search failed: " + e.message });
+  }
+});
+
 module.exports = router;

--- a/server/routes/offerings.js
+++ b/server/routes/offerings.js
@@ -79,10 +79,11 @@ router.get("/:code/:term", (req, res) => {
              COALESCE(pr.would_take_again, pr2.would_take_again) AS rmp_would_take_again,
              COALESCE(pr.rmp_url, pr2.rmp_url) AS rmp_url
       FROM course_offerings co
-      LEFT JOIN instructor_rmp_matches irm ON irm.instructor_name = co.instructor
+      LEFT JOIN instructor_rmp_matches irm ON irm.instructor_name = co.instructor AND irm.match_quality != 'none'
       LEFT JOIN professor_ratings pr ON pr.rmp_id = irm.rmp_id
       LEFT JOIN instructor_rmp_matches irm2 ON co.instructor LIKE '%,%'
         AND irm2.instructor_name = TRIM(SUBSTR(co.instructor, 1, INSTR(co.instructor, ',') - 1))
+        AND irm2.match_quality != 'none'
       LEFT JOIN professor_ratings pr2 ON pr2.rmp_id = irm2.rmp_id
       WHERE co.course_code IN (${placeholders}) AND co.term = ?
       ORDER BY co.section


### PR DESCRIPTION
## Summary
Admin UI to review, correct, and manually link RateMyProfessor professor matches.

**Server:**
- New `server/lib/rmp.js` — shared RMP GraphQL search + upsert helpers
- `GET /api/admin/rmp-matches` — paginated list with quality/name filters
- `PUT /api/admin/rmp-matches/:id` — confirm, break, or relink a match
- `GET /api/admin/rmp-search?name=...` — search RMP API for a professor
- `offerings.js` — filter out `match_quality = 'none'` so broken matches disappear from planner

**Client:**
- "Review RMP Matches" section in admin Tools tab
- Filter by quality (auto/manual/none) + search by name
- Confirm (auto → manual), Break (→ none), Search & Link actions
- Inline RMP search panel with Link buttons
- Pagination for large match lists

Fixes #66

## Test plan
- [ ] Admin Tools tab shows "Review RMP Matches" section
- [ ] Filter dropdown filters by match quality
- [ ] "Confirm" changes auto → manual
- [ ] "Break" removes the match, RMP badge disappears from planner for that instructor
- [ ] "Search & Link" opens search panel, searching returns RMP results
- [ ] "Link" associates the correct professor, rating appears in planner
- [ ] Pagination works for large lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)