### PR TITLE
Diagnose and fix missing section data

### DIFF
--- a/client/src/pages/Planner.jsx
+++ b/client/src/pages/Planner.jsx
@@ -1458,7 +1458,7 @@ function WeeklyScheduleView({ plan, coursesByTerm, actualByTerm = {}, planTerms,
           // Summary line for right side
           let rightContent;
           if (c.noData) {
-            rightContent = <span style={{ color: TEXT.muted, fontSize: TYPE.xs }}>no section data</span>;
+            rightContent = <span style={{ color: TEXT.muted, fontSize: TYPE.xs }}>not in LOCUS</span>;
           } else if (c.isTBA) {
             rightContent = <span style={{ color: TEXT.muted, fontSize: TYPE.xs }}>{"\u00A7"}{c.section} {"\u00B7"} TBA</span>;
           } else if (c.chosen) {

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -212,6 +212,28 @@ router.get("/scrape-locus/status", (req, res) => {
   res.json({ ...scrapeJob, stats });
 });
 
+// ── GET /api/admin/section-coverage ──────────────────────────────────────────
+router.get("/section-coverage", (req, res) => {
+  const term = req.query.term;
+  try {
+    const terms = db.prepare("SELECT DISTINCT term FROM course_offerings ORDER BY term").all().map(r => r.term);
+    const targetTerm = term || terms[terms.length - 1]; // default to most recent
+    if (!targetTerm) return res.json({ terms: [], departments: [], term: null });
+
+    const depts = db.prepare(`
+      SELECT SUBSTR(course_code, 1, 4) AS dept, COUNT(*) AS sections
+      FROM course_offerings WHERE term = ?
+      GROUP BY dept ORDER BY sections DESC
+    `).all(targetTerm);
+
+    const totalSections = depts.reduce((s, d) => s + d.sections, 0);
+
+    res.json({ term: targetTerm, terms, totalSections, departments: depts });
+  } catch (e) {
+    res.json({ term: null, terms: [], totalSections: 0, departments: [], error: e.message });
+  }
+});
+
 // ── POST /api/admin/scrape-catalog ───────────────────────────────────────────
 router.post("/scrape-catalog", (req, res) => {
   if (catalogJob.status === "running") {

--- a/server/scripts/scrape-locus.js
+++ b/server/scripts/scrape-locus.js
@@ -450,17 +450,39 @@ async function main() {
   console.log(`Subject errors: ${totalErrors}`);
   console.log(`Database: ${DB_PATH}`);
 
-  // Verify
+  // Verify + coverage report
   const verifyDb = new Database(DB_PATH);
   const offeringCount = verifyDb.prepare("SELECT COUNT(*) as c FROM course_offerings").get().c;
   const termCount = verifyDb.prepare("SELECT COUNT(*) as c FROM course_terms").get().c;
   const termList = verifyDb.prepare("SELECT term, COUNT(*) as c FROM course_offerings GROUP BY term").all();
-  verifyDb.close();
 
   console.log(`\nDB state: ${offeringCount} offerings, ${termCount} course-terms`);
   for (const t of termList) {
     console.log(`  ${t.term}: ${t.c} sections`);
   }
+
+  // Per-department coverage for scraped terms
+  for (const term of termsToScrape) {
+    const depts = verifyDb.prepare(`
+      SELECT SUBSTR(course_code, 1, 4) AS dept, COUNT(*) AS sections
+      FROM course_offerings WHERE term = ?
+      GROUP BY dept ORDER BY sections DESC
+    `).all(term.name);
+    const catalogDepts = verifyDb.prepare(`
+      SELECT DISTINCT SUBSTR(code, 1, 4) AS dept FROM courses
+    `).all().map(r => r.dept.trim());
+    const scrapedDepts = new Set(depts.map(d => d.dept.trim()));
+    const missing = catalogDepts.filter(d => !scrapedDepts.has(d));
+    const small = depts.filter(d => d.sections < 5);
+
+    console.log(`\n--- Coverage: ${term.name} ---`);
+    console.log(`  Departments with sections: ${depts.length}`);
+    console.log(`  Total sections: ${depts.reduce((s, d) => s + d.sections, 0)}`);
+    if (missing.length > 0) console.log(`  Missing departments (in catalog, no sections): ${missing.join(", ")}`);
+    if (small.length > 0) console.log(`  Small departments (<5 sections): ${small.map(d => `${d.dept.trim()}(${d.sections})`).join(", ")}`);
+  }
+
+  verifyDb.close();
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- Root cause identified: PLSC 311, PLSC 367, LITR 284, SOCL 311 aren't in LOCUS for Spring 2026 (special/cross-listed sections). Scraper is working correctly — 3,603 sections, 129 depts, 0 errors.
- Re-scraped both terms with fresh data
- Added per-department coverage report to scraper output
- Added `GET /api/admin/section-coverage` endpoint
- Section picker shows "not in LOCUS" instead of generic "no section data"

## Test plan
- [ ] Verify PLSC 337, ANTH 321, SPAN 104 have sections in weekly schedule
- [ ] Verify PLSC 311, LITR 284 show "not in LOCUS" (genuinely absent)
- [ ] Hit `/api/admin/section-coverage?term=Spring+2026` — should show 129 departments
- [ ] Run scraper and verify coverage report prints

Fixes #32. Progress on #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)